### PR TITLE
Feat/#34 implement local storage

### DIFF
--- a/apps/webstore/src/app/i18n/index.ts
+++ b/apps/webstore/src/app/i18n/index.ts
@@ -1,0 +1,1 @@
+export * from './locale.constants';

--- a/apps/webstore/src/app/i18n/locale.constants.ts
+++ b/apps/webstore/src/app/i18n/locale.constants.ts
@@ -1,0 +1,4 @@
+export enum Locale {
+  dk = 'dk',
+  en = 'en-US',
+}

--- a/apps/webstore/src/app/i18n/locale.constants.ts
+++ b/apps/webstore/src/app/i18n/locale.constants.ts
@@ -1,4 +1,4 @@
-export enum Locale {
+export enum LocaleType {
   dk = 'dk',
   en = 'en-US',
 }

--- a/apps/webstore/src/app/services/local-storage/index.ts
+++ b/apps/webstore/src/app/services/local-storage/index.ts
@@ -1,0 +1,2 @@
+export * from './local-storage.constants';
+export * from './local-storage.service';

--- a/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
@@ -1,4 +1,3 @@
 export enum LocalStorageVars {
-    locale = 'locale',
-  }
-  
+  locale = 'locale',
+}

--- a/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
@@ -1,0 +1,4 @@
+export enum LocalStorageVars {
+    locale = 'dk',
+  }
+  

--- a/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.constants.ts
@@ -1,4 +1,4 @@
 export enum LocalStorageVars {
-    locale = 'dk',
+    locale = 'locale',
   }
   

--- a/apps/webstore/src/app/services/local-storage/local-storage.service.spec.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LocalStorageService } from './local-storage.service';
+
+describe('LocalStorageService', () => {
+  let service: LocalStorageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LocalStorageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/webstore/src/app/services/local-storage/local-storage.service.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { Locale } from '../../i18n';
+import { LocaleType } from '../../i18n';
 import { LocalStorageVars } from './local-storage.constants';
 
 interface ICache {
@@ -17,10 +17,10 @@ export class LocalStorageService implements OnDestroy {
     // Initial state
     const initialLocale =
       JSON.parse(localStorage.getItem(LocalStorageVars.locale)) ||
-      Locale.dk;
+      LocaleType.dk;
 
     this.cache = {
-      [LocalStorageVars.locale]: new BehaviorSubject<Locale>(initialLocale),
+      [LocalStorageVars.locale]: new BehaviorSubject<LocaleType>(initialLocale),
     };
 
     window.addEventListener('storage', (e) => this.handleStorageUpdate(e));

--- a/apps/webstore/src/app/services/local-storage/local-storage.service.ts
+++ b/apps/webstore/src/app/services/local-storage/local-storage.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Locale } from '../../i18n';
+import { LocalStorageVars } from './local-storage.constants';
+
+interface ICache {
+  [key: string]: BehaviorSubject<unknown>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LocalStorageService implements OnDestroy {
+  private cache: ICache;
+
+  constructor() {
+    // Initial state
+    const initialLocale =
+      JSON.parse(localStorage.getItem(LocalStorageVars.locale)) ||
+      Locale.dk;
+
+    this.cache = {
+      [LocalStorageVars.locale]: new BehaviorSubject<Locale>(initialLocale),
+    };
+
+    window.addEventListener('storage', (e) => this.handleStorageUpdate(e));
+  }
+
+  // Lifecycle methods
+  ngOnDestroy(): void {
+    window.removeEventListener('storage', this.handleStorageUpdate.bind(this));
+  }
+
+  // Handlers
+  handleStorageUpdate({ key, newValue }: StorageEvent): void {
+    if (key && newValue) {
+      if (this.cache[key]) {
+        this.cache[key].next(JSON.parse(newValue));
+      }
+    }
+  }
+
+  // Methods
+  setItem<T>(key: string, value: T): BehaviorSubject<T> {
+    if (this.isLocalStorageSupported) {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+
+    if (this.cache[key]) {
+      this.cache[key].next(value);
+      return this.cache[key] as BehaviorSubject<T>;
+    }
+
+    return (this.cache[key] = new BehaviorSubject(value));
+  }
+
+  getItem<T>(key: string): BehaviorSubject<T> {
+    if (this.cache[key]) {
+      return this.cache[key] as BehaviorSubject<T>;
+    }
+
+    if (this.isLocalStorageSupported) {
+      return (this.cache[key] = new BehaviorSubject(
+        JSON.parse(localStorage.getItem(key))
+      ));
+    }
+    return null;
+  }
+
+  removeItem(key: string) {
+    if (this.isLocalStorageSupported) {
+      localStorage.removeItem(key);
+    }
+    if (this.cache[key]) this.cache[key].next(undefined);
+  }
+
+  get isLocalStorageSupported(): boolean {
+    return !!localStorage;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20227,9 +20227,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.6.tgz",
+      "integrity": "sha512-+eGgIo8Fl3l2B9Red9Q3VIkjMlUmaqELTJlsMqnHRe8V85DxJtr1q6Omjs0xBzXl0foNfCWu0fTf4jZ2LyWKPw==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "ts-jest": "26.4.0",
     "ts-node": "~9.1.1",
     "tslint": "~6.1.0",
-    "typescript": "^4.2.2"
+    "typescript": "^4.0.6"
   }
 }


### PR DESCRIPTION
## Local Storage Service

Implement Local Storage, aka storing app information like current Theme, Locale etc in the clients' browser

### Features:
 - Exists as a self-contained service
 - Pre-wired for Localization with Angular i18n (initialises for default locale of DK, includes a LocaleType Enum)
 - Utilises caching and subscription via BehaviourSubject, allowing it to automatically update other components when a stored value gets changed, and lower the number of reads on localStorage (that's as much you really need to understand tbh)
 
 ---
 ### How to use
 We will rarely write new functionality that utilises the localStorage service, thus you don't need to master it
 
 Whatever service uses LocalStorageService needs to:
  - create a variable of type `BehaviourSubject<ServiceType>` where ServiceType is a custom enum that specifies what values it can store.
  - constructor with `private localStorageService: LocalStorageService` and code for initializing the variable described above
  - methods that will read and change that variable
  
In the example below I have implemented those three in app.component.ts (just as an example, it normally will be its own service), with Locale functionality and LocaleType as its focus (relevant files can be found in the Pull Request changes).
```ts
import { Component } from '@angular/core';
import { BehaviorSubject } from 'rxjs';
import { LocaleType } from './i18n';
import { LocalStorageService, LocalStorageVars } from './services/local-storage';

@Component({
  selector: 'webstore-root',
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.css'],
})
export class AppComponent{

  currentLocale$: BehaviorSubject<LocaleType>; // stores the Locale state

  constructor(private localStorageService: LocalStorageService) {
    // get the default/pre-existing locale from the localStorage
    this.currentLocale$ = this.localStorageService.getItem<LocaleType>(LocalStorageVars.locale);

    // set the class variable to automatically update when the locale changes
    this.currentLocale$.subscribe(() => {
      console.log('Locale got changed: ' + this.currentLocale$.getValue());
    })
  }

  // simple method that can be triggered by the HTML elements. Simply switches between the two values
  changeLocale()
  {
    // get the opposite of the currently used locale. There are only two potential Locales at the moment
    const newLocale = this.currentLocale$.getValue() === LocaleType.dk ? LocaleType.en : LocaleType.dk;
    // update the local storage with the new locale
    this.localStorageService.setItem(LocalStorageVars.locale, newLocale);
  }
}

```
---
### Testing
Due to the complexity and browser-based behaviour of this feature, there are only tests that validate that the service gets created. There is no point testing if rxjs (source of BehaviorSubject) and localStorage (built-in angular feature) work properly

Instead, e2e tests must be written for the functionality that utilizes the localStorage (for example, Locale)

---
✅ Closes: #34 