### PR TITLE
fix: 🐛 Add credentials to the API test application.properties

### DIFF
--- a/apps/api/src/test/resources/application.properties
+++ b/apps/api/src/test/resources/application.properties
@@ -1,5 +1,7 @@
 # Database connection
 spring.datasource.url=jdbc:h2:~/test;
+spring.datasource.username=sa
+spring.datasource.password=
 spring.h2.console.enabled=true
 spring.h2.console.path=/test
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
The API tests were failing on some machines due to the  H2 database credentials missing.
This is fixed by adding default credentials to the config