### PR TITLE
ci: 🎡 Add a e2e testing workflow for CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,23 @@
+# Continuous Integration workflow for running end-to-end tests
+name: E2E CI 
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - name: Install and run end-to-end tests
+        # Install the apps using npm ci (ensures a clean install)
+        run: |
+          npm ci
+          npm run e2e:ci

--- a/apps/webstore-e2e/cypress.json
+++ b/apps/webstore-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "videosFolder": "../../dist/cypress/apps/webstore-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/webstore-e2e/screenshots",
   "chromeWebSecurity": false


### PR DESCRIPTION
### Add a Github actions workflow that automatically executes the e2e tests

It utilizes the `e2e:ci` script from package.json that runs the e2e tests in `headless` mode, aka console-only
___
✅ Closes: #51 