### PR TITLE
Feat/#77 implement newsletter signup

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/config/WebSecurityConfig.java
+++ b/apps/api/src/main/java/dk/treecreate/api/config/WebSecurityConfig.java
@@ -67,6 +67,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter
             .authorizeRequests()
             .antMatchers("/auth/**").permitAll()
             .antMatchers("/users/verification/{token}").permitAll()
+            .antMatchers("/newsletter/**").permitAll()
             .antMatchers("/healthcheck").permitAll()
             .antMatchers("/docs", // Swagger docs endpoints
                 "/v2/api-docs",

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/Newsletter.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/Newsletter.java
@@ -1,0 +1,103 @@
+package dk.treecreate.api.newsletter;
+
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.Date;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Newsletter",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = "email")
+    })
+public class Newsletter
+{
+
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(
+        name = "UUID",
+        strategy = "org.hibernate.id.UUIDGenerator",
+        parameters = {
+            @org.hibernate.annotations.Parameter(
+                name = "uuid_gen_strategy_class",
+                value = "org.hibernate.id.uuid.CustomVersionOneStrategy"
+            )
+        }
+    )
+    @Type(type = "uuid-char")
+    @ApiModelProperty(notes = "UUID of the newsletter entity",
+        example = "c0a80121-7ac0-190b-817a-c08ab0a12345")
+    private UUID newsletterId;
+
+    @NotBlank
+    @Size(max = 254)
+    @Email
+    @Column(name = "email", updatable = false, nullable = false)
+    @ApiModelProperty(name = "Subscribers email address", example = "example@hotdeals.dev",
+        required = true)
+    private String email;
+
+    @ApiModelProperty(name = "Date the newsletter entry was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    public Newsletter()
+    {
+    }
+
+
+    public UUID getNewsletterId()
+    {
+        return newsletterId;
+    }
+
+    public void setNewsletterId(UUID newsletterId)
+    {
+        this.newsletterId = newsletterId;
+    }
+
+    public String getEmail()
+    {
+        return email;
+    }
+
+    public void setEmail(String email)
+    {
+        this.email = email;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedDate(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    @Override public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Newsletter that = (Newsletter) o;
+        return newsletterId.equals(that.newsletterId) && email.equals(that.email) &&
+            createdAt.equals(that.createdAt);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(newsletterId, email, createdAt);
+    }
+}

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterController.java
@@ -1,0 +1,102 @@
+package dk.treecreate.api.newsletter;
+
+import dk.treecreate.api.authentication.services.AuthUserService;
+import dk.treecreate.api.exceptionhandling.ResourceNotFoundException;
+import dk.treecreate.api.newsletter.dto.GetNewslettersResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping("newsletter")
+@Api(tags = {"newsletter"})
+public class NewsletterController
+{
+    @Autowired
+    NewsletterRepository newsletterRepository;
+    @Autowired
+    AuthUserService authUserService;
+
+    @GetMapping()
+    @Operation(summary = "Get all newsletters")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "A list of newsletters",
+            response = GetNewslettersResponse.class)})
+    @PreAuthorize("hasRole('DEVELOPER') or hasRole('ADMIN')")
+    public List<Newsletter> getNewsletters()
+    {
+        return newsletterRepository.findAll();
+    }
+
+    @GetMapping("me")
+    @Operation(
+        summary = "Get a newsletter associated (via email) with the currently authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Newsletter information",
+            response = Newsletter.class),
+        @ApiResponse(code = 404, message = "Newsletter not found")
+    })
+    @PreAuthorize("hasRole('USER') or hasRole('DEVELOPER') or hasRole('ADMIN')")
+    public Newsletter getAssociatedNewsletter()
+    {
+        var userDetails = authUserService.getCurrentlyAuthenticatedUser();
+        return newsletterRepository.findByEmail(userDetails.getEmail())
+            .orElseThrow(() -> new ResourceNotFoundException("Newsletter not found"));
+    }
+
+    @GetMapping("{email}")
+    @Operation(summary = "Get a newsletter")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Newsletter information",
+            response = Newsletter.class),
+        @ApiResponse(code = 404, message = "Newsletter not found")})
+    @PreAuthorize("hasRole('DEVELOPER') or hasRole('ADMIN')")
+    public Newsletter getNewsletter(
+        @ApiParam(name = "email", example = "example@hotdeals.dev")
+        @PathVariable String email)
+    {
+        return newsletterRepository.findByEmail(email)
+            .orElseThrow(() -> new ResourceNotFoundException("Newsletter not found"));
+    }
+
+    @PostMapping("{email}")
+    @Operation(summary = "Create a new newsletter entry")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Newsletter information",
+            response = Newsletter.class)})
+    public Newsletter createNewsletter(
+        @ApiParam(name = "email", example = "example@hotdeals.dev")
+        @PathVariable String email)
+    {
+        Newsletter newsletter = new Newsletter();
+        newsletter.setEmail(email);
+        return newsletterRepository.save(newsletter);
+    }
+
+    @DeleteMapping("{newsletterId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Delete a newsletter entry")
+    @ApiResponses(value = {
+        @ApiResponse(code = 204, message = "Newsletter has been removed"),
+        @ApiResponse(code = 404, message = "Newsletter not found")})
+    public void deleteNewsletter(
+        @ApiParam(name = "Newsletter ID", example = "c0a80121-7ac0-190b-817a-c08ab0a12345")
+        @Valid @PathVariable UUID newsletterId)
+    {
+
+        Newsletter newsletter = newsletterRepository.findByNewsletterId(newsletterId)
+            .orElseThrow(() -> new ResourceNotFoundException("Newsletter not found"));
+        newsletterRepository.delete(newsletter);
+    }
+}

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterController.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -74,11 +75,17 @@ public class NewsletterController
     @Operation(summary = "Create a new newsletter entry")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Newsletter information",
-            response = Newsletter.class)})
+            response = Newsletter.class),
+        @ApiResponse(code = 400, message = "Duplicate newsletter")})
     public Newsletter createNewsletter(
         @ApiParam(name = "email", example = "example@hotdeals.dev")
         @PathVariable String email)
     {
+        if (newsletterRepository.existsByEmail(email))
+        {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "Email is already registered");
+        }
         Newsletter newsletter = new Newsletter();
         newsletter.setEmail(email);
         return newsletterRepository.save(newsletter);

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterRepository.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterRepository.java
@@ -12,4 +12,6 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long>
     Optional<Newsletter> findByEmail(String email);
 
     Optional<Newsletter> findByNewsletterId(UUID newsletterId);
+
+    Boolean existsByEmail(String email);
 }

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterRepository.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterRepository.java
@@ -1,0 +1,15 @@
+package dk.treecreate.api.newsletter;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface NewsletterRepository extends JpaRepository<Newsletter, Long>
+{
+    Optional<Newsletter> findByEmail(String email);
+
+    Optional<Newsletter> findByNewsletterId(UUID newsletterId);
+}

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/dto/GetNewslettersResponse.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/dto/GetNewslettersResponse.java
@@ -1,0 +1,12 @@
+package dk.treecreate.api.newsletter.dto;
+
+import dk.treecreate.api.newsletter.Newsletter;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+public class GetNewslettersResponse
+{
+    @ApiModelProperty(notes = "A list of newsletters")
+    List<Newsletter> newsletters;
+}

--- a/apps/api/src/test/java/dk/treecreate/api/newsletter/NewsletterControllerTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/newsletter/NewsletterControllerTests.java
@@ -1,0 +1,220 @@
+package dk.treecreate.api.newsletter;
+
+import dk.treecreate.api.TestUtilsService;
+import dk.treecreate.api.authentication.services.AuthUserService;
+import dk.treecreate.api.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class NewsletterControllerTests
+{
+
+    @MockBean
+    AuthUserService authUserService;
+    @Autowired
+    private MockMvc mvc;
+    @MockBean
+    private NewsletterRepository newsletterRepository;
+
+    @Nested
+    class AuthenticationTests
+    {
+
+        @Test
+        @DisplayName("GET /newsletter endpoint returns 401 when user credentials are invalid")
+        void getNewslettersReturnsUnauthorizedOnInvalidCredentials() throws Exception
+        {
+            mvc.perform(get("/newsletter"))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName(
+            "GET /newsletter/:newsletterId endpoint returns 401 when user credentials are invalid")
+        void getNewsletterReturnsUnauthorizedOnInvalidCredentials() throws Exception
+        {
+            UUID uuid = new UUID(0, 0);
+            mvc.perform(get("/newsletter/" + uuid))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("GET /newsletter/me endpoint returns 401 when user credentials are invalid")
+        void getNewsLetterOfUserReturnsUnauthorizedOnInvalidCredentials() throws Exception
+        {
+            mvc.perform(get("/newsletter/me"))
+                .andExpect(status().isUnauthorized());
+        }
+
+    }
+
+    @Nested
+    class GetNewslettersTests
+    {
+        @Test
+        @DisplayName("GET /newsletter endpoint returns 403: Forbidden when called by ROLE_USER")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword")
+        void getNewslettersReturnsForbiddenToRoleUser() throws Exception
+        {
+            mvc.perform(get("/newsletter"))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("GET /newsletter endpoint returns a list of newsletters")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword",
+            roles = {"DEVELOPER"})
+        void getNewslettersReturnsListOfUsers() throws Exception
+        {
+            List<Newsletter> list = new ArrayList<>();
+            list.add(new Newsletter());
+            list.get(0).setEmail("example0@hotdeals.dev");
+            list.add(new Newsletter());
+            list.get(1).setEmail("example1@hotdeals.dev");
+
+            Mockito.when(newsletterRepository.findAll()).thenReturn(list);
+
+            mvc.perform(get("/newsletter"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(TestUtilsService.asJsonString(list)));
+        }
+    }
+
+    @Nested
+    class GetNewsletterTests
+    {
+
+        @Test
+        @DisplayName(
+            "GET /newsletter/:email endpoint returns 403: Forbidden when called by ROLE_USER")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword")
+        void getNewsletterReturnsForbiddenToRoleUser() throws Exception
+        {
+            Newsletter newsletter = new Newsletter();
+            newsletter.setEmail("example@hotdeals.dev");
+            mvc.perform(get("/newsletter/" + newsletter.getEmail()))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("GET /newsletter endpoint returns a Newsletter")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword",
+            roles = {"DEVELOPER"})
+        void getNewsletterReturnsNewsletter() throws Exception
+        {
+            Newsletter newsletter = new Newsletter();
+            newsletter.setEmail("example@hotdeals.dev");
+
+            Mockito.when(newsletterRepository.findByEmail(newsletter.getEmail()))
+                .thenReturn(Optional.of(newsletter));
+
+            mvc.perform(get("/newsletter/" + newsletter.getEmail()))
+                .andExpect(status().isOk())
+                .andExpect(content().json(TestUtilsService.asJsonString(newsletter)));
+        }
+
+        @Test
+        @DisplayName(
+            "GET /newsletter/me endpoint returns a newsletter associated with currently authenticated user")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword")
+        void getAssociatedNewsletterReturnsNewsletter() throws Exception
+        {
+            User user = new User();
+            user.setEmail("user@hotdeals.dev");
+            user.setUsername(user.getEmail());
+
+            Newsletter newsletter = new Newsletter();
+            newsletter.setEmail(user.getEmail());
+
+            Mockito.when(newsletterRepository.findByEmail(user.getEmail()))
+                .thenReturn(Optional.of(newsletter));
+            Mockito.when(authUserService.getCurrentlyAuthenticatedUser())
+                .thenReturn(user);
+            mvc.perform(get("/newsletter/me"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(TestUtilsService.asJsonString(newsletter)));
+        }
+    }
+
+    @Nested
+    class CreateNewsletterTests
+    {
+        @Test
+        @DisplayName("POST /newsletter/:email endpoint returns a newsletter")
+        void createNewsletterReturnsNewsletter() throws Exception
+        {
+            Newsletter newsletter = new Newsletter();
+            newsletter.setNewsletterId(UUID.fromString("c0a80121-7adb-10c0-817a-dbc2f0ec1235"));
+            newsletter.setEmail("example@hotdeals.dev");
+
+
+            Mockito.when(newsletterRepository.existsByEmail(newsletter.getEmail()))
+                .thenReturn(false);
+            Mockito.when(newsletterRepository.save(newsletter))
+                .thenReturn((newsletter));
+
+            mvc.perform(post("/newsletter/" + newsletter.getEmail()))
+                .andExpect(status().isOk());
+        }
+
+
+        @Test
+        @DisplayName("POST /newsletter/:email retuns 400: Bad Request on duplicate email entry")
+        void createNewsletterReturnsBadRequestOnDuplicate() throws Exception
+        {
+            Newsletter newsletter = new Newsletter();
+            newsletter.setEmail("example@hotdeals.dev");
+
+            Mockito.when(newsletterRepository.existsByEmail(newsletter.getEmail()))
+                .thenReturn(true);
+
+            mvc.perform(post("/newsletter/" + newsletter.getEmail()))
+                .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class DeleteNewsletterTests
+    {
+
+        @Test
+        @DisplayName(
+            "DELETE /newsletter/:newsletterId endpoint returns 204: No Content when deleting a newsletter")
+        @WithMockUser(username = "user@hotdeals.dev", password = "testPassword")
+        void deleteNewsletterReturnsNewsletter()
+            throws Exception
+        {
+            Newsletter newsletter = new Newsletter();
+            newsletter.setNewsletterId(UUID.fromString("c0a80121-7adb-10c0-817a-dbc2f0ec1235"));
+
+            Mockito.when(newsletterRepository.findByNewsletterId(newsletter.getNewsletterId()))
+                .thenReturn(Optional.of(newsletter));
+            Mockito.doNothing().when(newsletterRepository).delete(newsletter);
+
+            mvc.perform(delete("/newsletter/" + newsletter.getNewsletterId()))
+                .andExpect(status().isNoContent());
+        }
+    }
+}

--- a/apps/webstore/src/app/shared/services/newsletter/newsletter.service.spec.ts
+++ b/apps/webstore/src/app/shared/services/newsletter/newsletter.service.spec.ts
@@ -1,0 +1,16 @@
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { NewsletterService } from './newsletter.service';
+
+describe('NewsletterService', () => {
+  let service: NewsletterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HttpClientModule] });
+    service = TestBed.inject(NewsletterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/webstore/src/app/shared/services/newsletter/newsletter.service.ts
+++ b/apps/webstore/src/app/shared/services/newsletter/newsletter.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { INewsletter } from '@interfaces';
+import { Observable } from 'rxjs';
+import { environment as env } from '../../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NewsletterService {
+  constructor(private http: HttpClient) {}
+
+  registerNewsletterEmail(email: string): Observable<INewsletter> {
+    return this.http.post<INewsletter>(`${env.apiUrl}/newsletter/${email}`, {});
+  }
+
+  unsubscribe(newsletterId: string): Observable<any> {
+    return this.http.delete(`${env.apiUrl}/newsletter/${newsletterId}`, {});
+  }
+}

--- a/libs/interfaces/src/lib/index.ts
+++ b/libs/interfaces/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
-export * from './user';
 export * from './design';
+export * from './newsletter';
+export * from './user';

--- a/libs/interfaces/src/lib/newsletter/index.ts
+++ b/libs/interfaces/src/lib/newsletter/index.ts
@@ -1,0 +1,2 @@
+export * from './newsletter.dto';
+export * from './newsletter.interface';

--- a/libs/interfaces/src/lib/newsletter/newsletter.dto.ts
+++ b/libs/interfaces/src/lib/newsletter/newsletter.dto.ts
@@ -1,0 +1,3 @@
+export class CreateNewsletterRequest {
+  email: string;
+}

--- a/libs/interfaces/src/lib/newsletter/newsletter.interface.ts
+++ b/libs/interfaces/src/lib/newsletter/newsletter.interface.ts
@@ -1,0 +1,5 @@
+export interface INewsletter {
+  newsletterId: string;
+  email: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Goal

<!-- What is this user story supposed to achieve, and what is the context -->

Allow creation and removal of newsletter signups
> Newsletter signup means the user agrees to be on a list of emails that we send out emails to regarding promotions etc

## Keypoints

<!--
    What the user story needs to include in order to be completed.
    The requirements can contain subsections to provide further information.
    Testing (both unit/integration and e2e tests) is implicitly required as per the definition of done. If you don't want them to be a requirement, state so explicitly
 -->
 
 - Has `NewsletterEmail` object which contains the following fields: 
   - `emailId:` UUID
   - `email`: String - unique, up to 254 chars, valid email
   - `createdAt:` DATE 
   > The `createdAt` date is used for GDPR compliance and statistics
 - Features the following endpoints:
   - GET `/newsletter/` - returns a list of newsletter emails that are registered on the list. _Only for Devs+_
   - GET `/newsletter/:email` - returns specific email based on the email value. _Only for Devs+_
   - GET `/newsletter/me` - returns an email associated (via email) with the currently authenticated user. _User+_
   - POST `/newsletter/:email` - registers a new email. _Public access_
   - DELETE `/newsletter/:token` - deletes the specified email, based on the token (encoded emailId). _Public access_
 - Includes a `newsletter.service.ts` class in the frontend, which maps out the various endpoints
 - Features swagger docs and tests

## Extra notes

<!-- If there is something special about the issue like a dependency, potential solutions or reference material it should be included -->

### Out of scope aka @Teodor25 has to implement it on his own
 - Connects the `Premium Offers` input field with the endpoints, allowing signup for the newsletter or whatever it becomes
 - Features a new page, `newsletter/unsubscribe/:newsletterId`, where you are redirected to via a link from a newsletter email. The page sends a request to the DELETE `/newsletter/:newsletterId` endpoint (via newsletterService), deleting the newsletterEmail entry
 - Adds an option on the user account information page to toggle newsletter subscription

