### PR TITLE
Test/#79 Add e2e tests for login and signup

### DIFF
--- a/apps/webstore-e2e/src/integration/components/navbar.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/navbar.spec.ts
@@ -1,5 +1,8 @@
 import { CookieStatus, LocalStorageVars } from '@models';
+import { AuthenticationService, AuthUserEnum } from '@webstore/mocks';
 describe('NavbarComponent', () => {
+  const authMockService = new AuthenticationService();
+
   beforeEach(() => {
     localStorage.setItem(
       LocalStorageVars.cookiesAccepted,
@@ -19,5 +22,16 @@ describe('NavbarComponent', () => {
     cy.get('[data-cy=navbar]').contains('Home').should('exist');
     cy.get('[data-cy=navbar]').contains('Product').should('exist');
     cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+    cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+  });
+
+  it('should display profile instead of log in when user is authenticated', () => {
+    localStorage.setItem(
+      LocalStorageVars.authUser,
+      JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser))
+    );
+
+    cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
+    cy.get('[data-cy=navbar]').contains('Profile').should('exist');
   });
 });

--- a/apps/webstore-e2e/src/integration/components/navbar.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/navbar.spec.ts
@@ -34,4 +34,16 @@ describe('NavbarComponent', () => {
     cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
     cy.get('[data-cy=navbar]').contains('Profile').should('exist');
   });
+
+  it('should log the out user and clear local storage information', () => {
+    localStorage.setItem(
+      LocalStorageVars.authUser,
+      JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser))
+    );
+    cy.get('[data-cy=navbar-profile-dropdown]').trigger('mouseenter');
+    cy.get('[data-cy=navbar-log-out-btn]').click({ force: true });
+    cy.url().should('contain', '/home');
+    cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+    cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+  });
 });

--- a/apps/webstore-e2e/src/integration/pages/login/login.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/login/login.spec.ts
@@ -1,10 +1,99 @@
 import { CookieStatus, LocalStorageVars } from '@models';
-describe('LoginPage', () => {
+import { AuthenticationService, AuthUserEnum } from '@webstore/mocks';
+
+describe('Login Page', () => {
+  const authMockService = new AuthenticationService();
+
   beforeEach(() => {
     localStorage.setItem(
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/login');
+  });
+
+  describe('Login page', () => {
+    beforeEach(() => {
+      cy.visit('/login');
+    });
+
+    it('should properly authenticate user with correct credentials', () => {
+      cy.intercept('POST', `/auth/signin`, {
+        body: authMockService.getMockUser(AuthUserEnum.authUser),
+        statusCode: 200,
+      }).as('signinRequest');
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+      cy.get('[data-cy=login-btn]').should('be.disabled');
+      cy.get('[data-cy=login-email-input]').type('e2e@test.com');
+      cy.get('[data-cy=login-password-input]').type('abcDEF123');
+      cy.get('[data-cy=login-btn]').should('be.enabled').click();
+      cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('exist');
+      cy.url().should('contain', '/home');
+    });
+
+    it('should refuse signin for user with incorrect credentials', () => {
+      cy.intercept('POST', `/auth/signin`, {
+        body: 'Unauthorized',
+        statusCode: 401,
+      }).as('signinRequest');
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+      cy.get('[data-cy=login-btn]').should('be.disabled');
+      cy.get('[data-cy=login-email-input]').type('e2e@test.com');
+      cy.get('[data-cy=login-password-input]').type('incorrectPassword');
+      cy.get('[data-cy=login-btn]').should('be.enabled').click();
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+      cy.url().should('contain', '/login');
+    });
+
+    it('should display a modal for forgot password when link is clicked', () => {
+      cy.get('[data-cy=forgot-password-btn]').click();
+      cy.get('[data-cy=forgot-password-modal-close-btn]').click();
+    });
+
+    it('should redirect to signup page when signup button is clicked', () => {
+      cy.get('[data-cy=login-signup-btn]').click();
+      cy.url().should('contain', '/signup');
+    });
+  });
+
+  describe('Local storage', () => {
+    it('should detect that the user is logged in', () => {
+      localStorage.setItem(
+        LocalStorageVars.authUser,
+        JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser))
+      );
+      cy.visit('/login');
+      // should get redirected away from login since the user is detected as logged in
+      cy.url().should('not.contain', '/login');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('exist');
+    });
+
+    it('should detect that the user is not logged in', () => {
+      cy.visit('/login');
+      cy.url().should('contain', '/login');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+    });
+
+    it('should detect that the access token is expired and log the user out', () => {
+      localStorage.setItem(
+        LocalStorageVars.authUser,
+        JSON.stringify(
+          authMockService.getMockUser(AuthUserEnum.authUserExpired)
+        )
+      );
+      cy.visit('/login');
+
+      cy.url().should('contain', '/login');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+    });
   });
 });

--- a/apps/webstore-e2e/src/integration/pages/signup/signup.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/signup/signup.spec.ts
@@ -1,0 +1,125 @@
+import { CookieStatus, LocalStorageVars } from '@models';
+import { AuthenticationService, AuthUserEnum } from '@webstore/mocks';
+
+describe('Signup Page', () => {
+  const authMockService = new AuthenticationService();
+
+  beforeEach(() => {
+    localStorage.setItem(
+      LocalStorageVars.cookiesAccepted,
+      `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
+    );
+  });
+
+  describe('Signup page', () => {
+    beforeEach(() => {
+      cy.visit('/signup');
+    });
+
+    it('should properly create a new user with correct credentials', () => {
+      cy.intercept('POST', `/auth/signup`, {
+        body: authMockService.getMockUser(AuthUserEnum.authUser),
+        statusCode: 200,
+      }).as('signupRequest');
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      cy.get('[data-cy=signup-email-input]').type('e2e@test.com');
+      cy.get('[data-cy=signup-password-input]').type('abcDEF123');
+      cy.get('[data-cy=signup-confirm-password-input]').type('abcDEF123');
+      cy.get('[data-cy=checkbox-terms-of-use]').click();
+      cy.get('[data-cy=checkbox-newsletter]').click();
+      cy.get('[data-cy=signup-btn]').should('be.enabled').click();
+      cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('exist');
+      cy.url().should('contain', '/profile');
+    });
+
+    it('should refuse signup for user with incorrect credentials', () => {
+      cy.intercept('POST', `/auth/signup`, {
+        body: authMockService.getMockUser(AuthUserEnum.authUser),
+        statusCode: 200,
+      }).as('signupRequest');
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      cy.get('[data-cy=signup-email-input]').type('e2e@test.com');
+      cy.get('[data-cy=signup-password-input]').type('abcDEF123');
+      cy.get('[data-cy=checkbox-terms-of-use]').click();
+      cy.get('[data-cy=checkbox-newsletter]').click();
+      // check that confirm password validation works
+      cy.get('[data-cy=signup-confirm-password-input]').type('abcDEF1234');
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      cy.get('[data-cy=signup-confirm-password-error').should('exist');
+      cy.get('[data-cy=signup-confirm-password-input]')
+        .clear()
+        .type('abcDEF123');
+      cy.get('[data-cy=signup-confirm-password-error').should('not.exist');
+      cy.get('[data-cy=signup-btn]').should('be.enabled');
+      // check that email validation works
+      cy.get('[data-cy=signup-email-input]').clear().type('e2etest.com');
+      cy.get('[data-cy=signup-email-error').should('exist');
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      cy.get('[data-cy=signup-email-input]').clear().type('e2e@test.com');
+      cy.get('[data-cy=signup-email-error').should('not.exist');
+      cy.get('[data-cy=signup-btn]').should('be.enabled');
+      // check that password validation works
+      cy.get('[data-cy=signup-password-input]').clear().type('abcDEF');
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      cy.get('[data-cy=signup-password-error').should('exist');
+      cy.get('[data-cy=signup-password-input]').clear().type('abcDEF123');
+      cy.get('[data-cy=signup-password-error').should('not.exist');
+      // all of the inputs are correct
+      cy.get('[data-cy=signup-btn]').should('be.enabled');
+      // Uncheck terms od use
+      cy.get('[data-cy=checkbox-terms-of-use]').click();
+      cy.get('[data-cy=signup-btn]').should('be.disabled');
+      // Uncheck newsletter (shouldn't be needed)
+      cy.get('[data-cy=checkbox-terms-of-use]').click();
+      cy.get('[data-cy=checkbox-newsletter]').click();
+    });
+
+    it('should redirect to login page when button is clicked', () => {
+      cy.get('[data-cy=signup-redirect-login-btn]').click();
+      cy.url().should('contain', '/login');
+    });
+  });
+
+  describe('Local storage', () => {
+    it('should detect that the user is logged in', () => {
+      localStorage.setItem(
+        LocalStorageVars.authUser,
+        JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser))
+      );
+      cy.visit('/signup');
+      // should get redirected away from login since the user is detected as logged in
+      cy.url().should('not.contain', '/login');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('not.exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('exist');
+    });
+
+    it('should detect that the user is not logged in', () => {
+      cy.visit('/signup');
+      cy.url().should('contain', '/signup');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+    });
+
+    it('should detect that the access token is expired and log the user out', () => {
+      localStorage.setItem(
+        LocalStorageVars.authUser,
+        JSON.stringify(
+          authMockService.getMockUser(AuthUserEnum.authUserExpired)
+        )
+      );
+      cy.visit('/signup');
+
+      cy.url().should('contain', '/signup');
+
+      cy.get('[data-cy=navbar]').contains('Log In').should('exist');
+      cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
+    });
+  });
+});

--- a/apps/webstore/src/app/pages/auth/signup/signup.component.html
+++ b/apps/webstore/src/app/pages/auth/signup/signup.component.html
@@ -16,6 +16,7 @@
                 id="email"
                 autocomplete="email"
                 required
+                data-cy="signup-email-input"
             />
             <label for="email" class="tc-input-label">E-mail</label>
         </div>
@@ -26,6 +27,7 @@
                 this.signupForm.get('email').dirty &&
                 this.signupForm.get('email').invalid
             "
+            data-cy="signup-email-error"
         >
             Invalid e-mail
         </div>
@@ -40,6 +42,7 @@
                 id="password"
                 autocomplete="new-password"
                 required
+                data-cy="signup-password-input"
             />
             <label for="password" class="tc-input-label">Password</label>
         </div>
@@ -50,6 +53,7 @@
                 this.signupForm.get('password').dirty &&
                 this.signupForm.get('password').invalid
             "
+            data-cy="signup-password-error"
         >
             Must contain at least one upper- and lowecase letter and a number.
         </div>
@@ -64,6 +68,7 @@
                 id="confirmPassword"
                 autocomplete="new-password"
                 required
+                data-cy="signup-confirm-password-input"
             />
             <label for="confirmPassword" class="tc-input-label"
                 >Confirm password</label
@@ -76,6 +81,7 @@
                 this.signupForm.get('confirmPassword').dirty &&
                 !this.matchingPasswords()
             "
+            data-cy="signup-confirm-password-error"
         >
             The passwords must match each other
         </div>
@@ -87,7 +93,7 @@
                         this.termsAndConditions = !this.termsAndConditions
                     "
                 />
-                <span class="checkmark" data-cy="checkbox-big-font"></span>
+                <span class="checkmark" data-cy="checkbox-terms-of-use"></span>
             </label>
             <div class="terms-and-conditions">
                 I accept terms and conditions<a
@@ -106,7 +112,7 @@
                         this.signUpForNewletter = !this.signUpForNewletter
                     "
                 />
-                <span class="checkmark" data-cy="checkbox-big-font"></span>
+                <span class="checkmark" data-cy="checkbox-newsletter"></span>
             </label>
             <!-- TODO: Make the link to terms and conditions more obvious (looks like normal, non-clickable text) -->
             <div class="sign-up">
@@ -119,27 +125,18 @@
             type="submit"
             [ngClass]="isDisabled() ? 'disabled' : ''"
             [disabled]="isDisabled()"
+            data-cy="signup-btn"
         >
             Create Account
         </button>
 
-        <button class="tc-button-100" type="button" routerLink="/login">
+        <button
+            class="tc-button-100"
+            type="button"
+            routerLink="/login"
+            data-cy="signup-redirect-login-btn"
+        >
             Back to login
         </button>
     </form>
 </div>
-
-<!-- For cy tests -->
-<div class="hide" data-cy="signup-email">
-    {{ this.signupForm.get('email').value }}
-</div>
-<div class="hide" data-cy="signup-password">
-    {{ this.signupForm.get('password').value }}
-</div>
-<div class="hide" data-cy="signup-confirm-password">
-    {{ this.signupForm.get('confirmPassword').value }}
-</div>
-<div class="hide" data-cy="signup-terms-and-conditions">
-    {{ this.termsAndConditions }}
-</div>
-<!-- cy test end -->

--- a/apps/webstore/src/app/shared/components/modals/forgot-password-modal/forgot-password-modal.component.html
+++ b/apps/webstore/src/app/shared/components/modals/forgot-password-modal/forgot-password-modal.component.html
@@ -55,6 +55,7 @@
                     type="button"
                     class="tc-button-50"
                     (click)="activeModal.close()"
+                    data-cy="forgot-password-modal-close-btn"
                 >
                     Close
                 </button>

--- a/apps/webstore/src/app/shared/components/navbar/navbar.component.html
+++ b/apps/webstore/src/app/shared/components/navbar/navbar.component.html
@@ -109,6 +109,7 @@
                         class="nav-link waves-light"
                         *ngIf="isLoggedIn"
                         (click)="logout(); autoCollapse()"
+                        data-cy="navbar-log-out-btn"
                         >Log out</a
                     >
                 </li>
@@ -125,6 +126,7 @@
                             ngbDropdownToggle
                             class="nav-link waves-light"
                             (mouseenter)="showProfileMenu()"
+                            data-cy="navbar-profile-dropdown"
                             >Profile</a
                         >
                         <div

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
     '<rootDir>/apps/webstore',
     '<rootDir>/libs/models',
     '<rootDir>/libs/interfaces',
+    '<rootDir>/libs/mocks',
   ],
 };

--- a/libs/mocks/.eslintrc.json
+++ b/libs/mocks/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "parserOptions": { "project": ["libs/mocks/tsconfig.*?.json"] },
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          { "type": "attribute", "prefix": "webstore", "style": "camelCase" }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          { "type": "element", "prefix": "webstore", "style": "kebab-case" }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/mocks/README.md
+++ b/libs/mocks/README.md
@@ -1,0 +1,3 @@
+# mocks
+
+This library contains various classes and variables used for mocking within the typescript applications (webstore, webstore-e2e etc)

--- a/libs/mocks/jest.config.js
+++ b/libs/mocks/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'mocks',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../coverage/libs/mocks',
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js',
+  ],
+};

--- a/libs/mocks/src/index.ts
+++ b/libs/mocks/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/authentication';

--- a/libs/mocks/src/lib/authentication/auth-user.enum.ts
+++ b/libs/mocks/src/lib/authentication/auth-user.enum.ts
@@ -1,0 +1,8 @@
+export enum AuthUserEnum {
+  authUser,
+  authUserRoleDeveloper,
+  authUserRoleOwner,
+  authUserExpired,
+  authUserInvalid,
+  authUserNotVerified,
+}

--- a/libs/mocks/src/lib/authentication/auth-user.mock.ts
+++ b/libs/mocks/src/lib/authentication/auth-user.mock.ts
@@ -1,0 +1,55 @@
+import { IAuthUser } from '@interfaces';
+
+export const authUser: IAuthUser = {
+  email: 'e2e@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: true,
+};
+
+export const authUserRoleDeveloper: IAuthUser = {
+  email: 'e2e-dev@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER', 'ROLE_DEVELOPER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: true,
+};
+
+export const authUserRoleOwner: IAuthUser = {
+  email: 'e2e-owner@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER', 'ROLE_OWNER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: true,
+};
+
+export const authUserExpired: IAuthUser = {
+  email: 'e2e-expired@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: true,
+};
+
+export const authUserInvalid: IAuthUser = {
+  email: 'e2e-invalid@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER', 'ROLE_DEVELOPER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: true,
+};
+
+export const authUserNotVerified: IAuthUser = {
+  email: 'e2e-not-verified@test.com',
+  accessToken: '',
+  roles: ['ROLE_USER', 'ROLE_DEVELOPER'],
+  tokenType: 'Bearer',
+  userId: '7f000001-7b0d-19bf-817b-0d0a8ec40000',
+  isVerified: false,
+};

--- a/libs/mocks/src/lib/authentication/authentication.service.ts
+++ b/libs/mocks/src/lib/authentication/authentication.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@angular/core';
+import { IAuthUser } from '@interfaces';
+import { AuthUserEnum } from '.';
+import {
+  authUser,
+  authUserExpired,
+  authUserInvalid,
+  authUserRoleDeveloper,
+  authUserRoleOwner,
+} from './auth-user.mock';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthenticationService {
+  header = {
+    alg: 'none',
+  };
+  constructor() {}
+
+  getMockUser(authUserType: AuthUserEnum): IAuthUser {
+    let authUserMock: IAuthUser;
+    switch (authUserType) {
+      case AuthUserEnum.authUser:
+        authUserMock = authUser;
+        authUserMock.accessToken = this.generateAccessToken(
+          true,
+          authUserMock.email
+        );
+        break;
+      case AuthUserEnum.authUserRoleDeveloper:
+        authUserMock = authUserRoleDeveloper;
+        authUserMock.accessToken = this.generateAccessToken(
+          true,
+          authUserMock.email
+        );
+        break;
+      case AuthUserEnum.authUserRoleOwner:
+        authUserMock = authUserRoleOwner;
+        authUserMock.accessToken = this.generateAccessToken(
+          true,
+          authUserMock.email
+        );
+        break;
+      case AuthUserEnum.authUserExpired:
+        authUserMock = authUserExpired;
+        authUserMock.accessToken = this.generateAccessToken(
+          false,
+          authUserMock.email
+        );
+        break;
+      case AuthUserEnum.authUserInvalid:
+        authUserMock = authUserInvalid;
+        break;
+    }
+    return authUserMock;
+  }
+
+  private generateAccessToken(validExpDate: boolean, email: string): string {
+    const currentDate = new Date();
+
+    const data = {
+      sub: email,
+      // Set the issued date to yesterday
+      iat: Math.floor(
+        new Date(currentDate.getTime() - 86400000).getTime() / 1000
+      ),
+      // If the token should be still valid, the exp date is ahead of today. Otherwise, it is before
+      exp: Math.floor(
+        new Date(
+          currentDate.getTime() + (validExpDate ? 86400000 : -86400000)
+        ).getTime() / 1000
+      ),
+    };
+    // return the encoded access token
+    return `${this.encodeBase64url(
+      JSON.stringify(this.header)
+    )}.${this.encodeBase64url(JSON.stringify(data))}`;
+  }
+
+  private encodeBase64url(data: string): string {
+    return btoa(data)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  }
+}

--- a/libs/mocks/src/lib/authentication/index.ts
+++ b/libs/mocks/src/lib/authentication/index.ts
@@ -1,0 +1,2 @@
+export * from './auth-user.enum';
+export * from './authentication.service';

--- a/libs/mocks/src/test-setup.ts
+++ b/libs/mocks/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/mocks/tsconfig.json
+++ b/libs/mocks/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/mocks/tsconfig.lib.json
+++ b/libs/mocks/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/mocks/tsconfig.spec.json
+++ b/libs/mocks/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -25,6 +25,7 @@
     "webstore": { "tags": [] },
     "webstore-e2e": { "tags": [], "implicitDependencies": ["webstore"] },
     "models": { "tags": [] },
-    "interfaces": { "tags": [] }
+    "interfaces": { "tags": [] },
+    "mocks": { "tags": [] }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webstore",
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "baseUrl": ".",
     "paths": {
       "@models": ["libs/models/src/index.ts"],
-      "@interfaces": ["libs/interfaces/src/index.ts"]
+      "@interfaces": ["libs/interfaces/src/index.ts"],
+      "@webstore/mocks": ["libs/mocks/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -1,13 +1,23 @@
 {
   "version": 2,
-  "cli": { "defaultCollection": "@nrwl/angular" },
+  "cli": {
+    "defaultCollection": "@nrwl/angular"
+  },
   "generators": {
     "@nrwl/angular:application": {
+      "style": "css",
+      "linter": "eslint",
       "unitTestRunner": "jest",
       "e2eTestRunner": "cypress"
     },
-    "@nrwl/angular:library": { "unitTestRunner": "jest" },
-    "@nrwl/angular:component": { "style": "css" }
+    "@nrwl/angular:library": {
+      "style": "css",
+      "linter": "eslint",
+      "unitTestRunner": "jest"
+    },
+    "@nrwl/angular:component": {
+      "style": "css"
+    }
   },
   "projects": {
     "api": {
@@ -17,35 +27,51 @@
       "targets": {
         "run": {
           "executor": "@nxrocks/nx-spring-boot:run",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "serve": {
           "executor": "@nxrocks/nx-spring-boot:serve",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "test": {
           "executor": "@nxrocks/nx-spring-boot:test",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "clean": {
           "executor": "@nxrocks/nx-spring-boot:clean",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "buildJar": {
           "executor": "@nxrocks/nx-spring-boot:buildJar",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "buildWar": {
           "executor": "@nxrocks/nx-spring-boot:buildWar",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "buildImage": {
           "executor": "@nxrocks/nx-spring-boot:buildImage",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         },
         "buildInfo": {
           "executor": "@nxrocks/nx-spring-boot:buildInfo",
-          "options": { "root": "apps/api" }
+          "options": {
+            "root": "apps/api"
+          }
         }
       }
     },
@@ -56,7 +82,9 @@
       "prefix": "webstore",
       "i18n": {
         "sourceLocale": "en-US",
-        "locales": { "dk": "apps/webstore/src/i18n/messages.dk.xlf" }
+        "locales": {
+          "dk": "apps/webstore/src/i18n/messages.dk.xlf"
+        }
       },
       "targets": {
         "build": {
@@ -119,15 +147,23 @@
         },
         "serve": {
           "executor": "@angular-devkit/build-angular:dev-server",
-          "options": { "browserTarget": "webstore:build" },
+          "options": {
+            "browserTarget": "webstore:build"
+          },
           "configurations": {
-            "production": { "browserTarget": "webstore:build:production" },
-            "dk": { "browserTarget": "webstore:build:dk" }
+            "production": {
+              "browserTarget": "webstore:build:production"
+            },
+            "dk": {
+              "browserTarget": "webstore:build:dk"
+            }
           }
         },
         "extract-i18n": {
           "executor": "@angular-devkit/build-angular:extract-i18n",
-          "options": { "browserTarget": "webstore:build" }
+          "options": {
+            "browserTarget": "webstore:build"
+          }
         },
         "lint": {
           "executor": "@nrwl/linter:eslint",
@@ -161,13 +197,19 @@
             "devServerTarget": "webstore:serve"
           },
           "configurations": {
-            "production": { "devServerTarget": "webstore:serve:production" },
-            "dk": { "devServerTarget": "webstore:serve:dk" }
+            "production": {
+              "devServerTarget": "webstore:serve:production"
+            },
+            "dk": {
+              "devServerTarget": "webstore:serve:dk"
+            }
           }
         },
         "lint": {
           "executor": "@nrwl/linter:eslint",
-          "options": { "lintFilePatterns": ["apps/webstore-e2e/**/*.{js,ts}"] }
+          "options": {
+            "lintFilePatterns": ["apps/webstore-e2e/**/*.{js,ts}"]
+          }
         }
       }
     },
@@ -178,7 +220,9 @@
       "targets": {
         "lint": {
           "executor": "@nrwl/linter:eslint",
-          "options": { "lintFilePatterns": ["libs/models/**/*.ts"] }
+          "options": {
+            "lintFilePatterns": ["libs/models/**/*.ts"]
+          }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
@@ -197,13 +241,40 @@
       "targets": {
         "lint": {
           "executor": "@nrwl/linter:eslint",
-          "options": { "lintFilePatterns": ["libs/interfaces/**/*.ts"] }
+          "options": {
+            "lintFilePatterns": ["libs/interfaces/**/*.ts"]
+          }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/interfaces"],
           "options": {
             "jestConfig": "libs/interfaces/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "mocks": {
+      "projectType": "library",
+      "root": "libs/mocks",
+      "sourceRoot": "libs/mocks/src",
+      "prefix": "webstore",
+      "targets": {
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/mocks/src/**/*.ts",
+              "libs/mocks/src/**/*.html"
+            ]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/mocks"],
+          "options": {
+            "jestConfig": "libs/mocks/jest.config.js",
             "passWithNoTests": true
           }
         }


### PR DESCRIPTION
## Goal

Provide a way to mock authentication during e2e testing

## Keynotes
This pull request includes:

- New library, `@webstore/mocks`. Contains:
  - `AuthUser` mocks of various states, used by the service and enum. Shouldn't be used directly since their access token is invalid
  - `AuthUserEnum` - an enum of pre-defined AuthUser mocks, used by the AuthMockService.
  - `AuthMockService` - a service with a single public method, `getMockUser(AuthUserEnum)`. Returns a mock user data, with access token generated according to mock type
- Defined way of mocking the status of being authenticated
  > Include the following code in your e2e tests wherever you want to be authenticated
  Auth user enum value depends on what state you want (verified etc)
  ```ts
  localStorage.setItem(
        LocalStorageVars.authUser,
        JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser))
      );
  ```
 - New e2e specs for login and signup pages, as well as the login button in the navbar
___

✅ Closes: #79 
