### PR TITLE
Refactor/#139 optimise family tree design

### DIFF
--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -106,10 +106,11 @@ export class FamilyTreeDesignComponent
 
   // render loop
   timeInterval;
-  framesPerSecond = 60; // FPS of the render loop
+  framesPerSecond = 30; // FPS of the render loop
   // autosaving of the design
   autosaveFrequencyInSeconds = 30;
   autosaveInterval;
+  frameChanged = true;
 
   // SVGs
 
@@ -232,7 +233,7 @@ export class FamilyTreeDesignComponent
       dismissible: false,
     };
     // stop the canvas rendering process
-    cancelAnimationFrame(this.timeInterval);
+    clearInterval(this.timeInterval);
     clearInterval(this.autosaveInterval);
     this.autosaveInterval = null;
     this.isDesignValid = false;
@@ -250,8 +251,14 @@ export class FamilyTreeDesignComponent
 
     for (let i = 0; i < this.myBoxes.length; i++) {}
     // run the render loop
-    cancelAnimationFrame(this.timeInterval);
-    this.draw();
+    clearInterval(this.timeInterval);
+
+    this.timeInterval = setInterval(() => {
+      console.log(this.frameChanged);
+      if (this.frameChanged) {
+        requestAnimationFrame(this.draw.bind(this));
+      }
+    }, 1000 / this.framesPerSecond);
     console.log('Render loop started');
 
     // start autosave of design
@@ -322,14 +329,12 @@ export class FamilyTreeDesignComponent
     this.cdr.detectChanges();
 
     this.myBoxes.push(newBox);
+    this.frameChanged = true;
   }
 
   // Draw the entire canvas with the boxes etc
   draw() {
     try {
-      // https://medium.com/angular-in-depth/how-to-get-started-with-canvas-animations-in-angular-2f797257e5b4
-      this.timeInterval = requestAnimationFrame(this.draw.bind(this));
-
       this.context.clearRect(
         0,
         0,
@@ -481,10 +486,11 @@ export class FamilyTreeDesignComponent
           this.context.fillText(line, x, y);
         }
       }
+      this.frameChanged = false;
     } catch (error) {
       console.error('An error has occurred while drawing the tree', error);
       // disable autosave and the drawing loop
-      cancelAnimationFrame(this.timeInterval);
+      clearInterval(this.timeInterval);
       clearInterval(this.autosaveInterval);
       this.autosaveInterval = null;
       this.alert = {
@@ -549,6 +555,7 @@ export class FamilyTreeDesignComponent
       }
       console.log('Boxes', this.myBoxes);
       console.log('Finished loading design');
+      this.frameChanged = true;
       this.cdr.detectChanges();
     } catch (error) {
       console.error('Something went wrong while loading the design!', error);
@@ -558,7 +565,7 @@ export class FamilyTreeDesignComponent
         dismissible: false,
       };
       console.log('interval', this.timeInterval);
-      cancelAnimationFrame(this.timeInterval);
+      clearInterval(this.timeInterval);
       clearInterval(this.autosaveInterval);
       this.isDesignValid = false;
     }
@@ -638,6 +645,7 @@ export class FamilyTreeDesignComponent
         box.inputRef.instance.largeFont = this.isLargeFont;
       });
     }
+    this.frameChanged = true;
     this.cdr.detectChanges();
   }
 
@@ -702,150 +710,162 @@ export class FamilyTreeDesignComponent
   }
 
   mouseDownHandler(event) {
-    event = event || window.event;
-    // if the mouse down/touchdown event got triggered, don't allow any new down events for 100ms
-    if (this.downEventDelay) {
-      return;
-    } else {
-      this.downEventDelay = true;
-      setTimeout(() => (this.downEventDelay = false), 100);
-    }
-
-    this.mouseCords = this.getMousePosition(
-      this.designCanvas.nativeElement,
-      event
-    );
-    for (let i = 0; i < this.myBoxes.length; i++) {
-      const box = this.myBoxes[i];
-
-      if (
-        this.mouseCords.x > box.x &&
-        this.mouseCords.x < box.x + this.boxDimensions.width &&
-        this.mouseCords.y > box.y &&
-        this.mouseCords.y < box.y + this.boxDimensions.height
-      ) {
-        // check if the Close button got pressed
-        if (
-          this.mouseCords.x > box.x &&
-          this.mouseCords.x < box.x + this.closeButtonDimensions.width &&
-          this.mouseCords.y > box.y &&
-          this.mouseCords.y < box.y + this.closeButtonDimensions.width
-        ) {
-          // remove the box and the input component
-          this.myBoxes[i].inputRef.destroy();
-          this.myBoxes.splice(i, 1);
-          return;
-        }
-
-        this.myBoxes[i].dragging = true;
-        this.mouseClickOffset.x = this.mouseCords.x - box.x;
-        this.mouseClickOffset.y = this.mouseCords.y - box.y;
-        // swap the dragged box to the top of rending order, displaying it on top of the other boxes
-        const temp = this.myBoxes[this.myBoxes.length - 1];
-        this.myBoxes[this.myBoxes.length - 1] = this.myBoxes[i];
-        this.myBoxes[i] = temp;
-        // skip checking the other boxes
+    try {
+      event = event || window.event;
+      // if the mouse down/touchdown event got triggered, don't allow any new down events for 100ms
+      if (this.downEventDelay) {
         return;
+      } else {
+        this.downEventDelay = true;
+        setTimeout(() => (this.downEventDelay = false), 100);
       }
-    }
-    // this will only be reached if none of the boxes was clicked on
-    // create new box
-    this.createBox(
-      this.mouseCords.x - this.boxDimensions.width / 2,
-      this.mouseCords.y - this.boxDimensions.height / 2,
-      Object.values(BoxDesignEnum)[
-        Math.floor(Math.random() * this.tree1BoxDesigns.size)
-      ],
-      ''
-    );
 
-    // auto-focus on the newly created element
-    setTimeout(() => {
-      this.myBoxes[
-        this.myBoxes.length - 1
-      ].inputRef.instance.input.nativeElement.focus();
-    });
-  }
+      this.mouseCords = this.getMousePosition(
+        this.designCanvas.nativeElement,
+        event
+      );
+      for (let i = 0; i < this.myBoxes.length; i++) {
+        const box = this.myBoxes[i];
 
-  // the mousemove event is not available as a angular attribute so it has to be declared explicitly
-  @HostListener('document:mousemove', ['$event'])
-  mouseMoveHandler(event) {
-    event = event || window.event;
-    this.mouseCords = this.getMousePosition(
-      this.designCanvas.nativeElement,
-      event
-    );
-
-    let boxesGotMousedOver = false;
-
-    for (let i = 0; i < this.myBoxes.length; i++) {
-      const box = this.myBoxes[i];
-      if (
-        !this.mouseOutsideBoundaries(
-          this.boxDimensions.width,
-          this.boxDimensions.height
-        )
-      ) {
-        // check if any of the boxes got moused over
         if (
           this.mouseCords.x > box.x &&
           this.mouseCords.x < box.x + this.boxDimensions.width &&
           this.mouseCords.y > box.y &&
           this.mouseCords.y < box.y + this.boxDimensions.height
         ) {
-          boxesGotMousedOver = true;
-          this.showDeleteBoxButtons = true;
-        }
-        if (box.dragging) {
-          {
-            // move the box with the cursor
-            this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
-            this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
-            // skip checking the other boxes
+          // check if the Close button got pressed
+          if (
+            this.mouseCords.x > box.x &&
+            this.mouseCords.x < box.x + this.closeButtonDimensions.width &&
+            this.mouseCords.y > box.y &&
+            this.mouseCords.y < box.y + this.closeButtonDimensions.width
+          ) {
+            // remove the box and the input component
+            this.myBoxes[i].inputRef.destroy();
+            this.myBoxes.splice(i, 1);
             return;
           }
+
+          this.myBoxes[i].dragging = true;
+          this.mouseClickOffset.x = this.mouseCords.x - box.x;
+          this.mouseClickOffset.y = this.mouseCords.y - box.y;
+          // swap the dragged box to the top of rending order, displaying it on top of the other boxes
+          const temp = this.myBoxes[this.myBoxes.length - 1];
+          this.myBoxes[this.myBoxes.length - 1] = this.myBoxes[i];
+          this.myBoxes[i] = temp;
+          // skip checking the other boxes
+          return;
         }
       }
-    }
-    // only stop showing the delete button if none of the boxes got moused over
-    if (!boxesGotMousedOver) {
-      this.showDeleteBoxButtons = false;
+      // this will only be reached if none of the boxes was clicked on
+      // create new box
+      this.createBox(
+        this.mouseCords.x - this.boxDimensions.width / 2,
+        this.mouseCords.y - this.boxDimensions.height / 2,
+        Object.values(BoxDesignEnum)[
+          Math.floor(Math.random() * this.tree1BoxDesigns.size)
+        ],
+        ''
+      );
+
+      // auto-focus on the newly created element
+      setTimeout(() => {
+        this.myBoxes[
+          this.myBoxes.length - 1
+        ].inputRef.instance.input.nativeElement.focus();
+      });
+    } finally {
+      this.frameChanged = true;
     }
   }
 
-  mouseUpHandler(event) {
-    event = event || window.event;
-    this.mouseCords = this.getMousePosition(
-      this.designCanvas.nativeElement,
-      event
-    );
+  // the mousemove event is not available as a angular attribute so it has to be declared explicitly
+  @HostListener('document:mousemove', ['$event'])
+  mouseMoveHandler(event) {
+    try {
+      event = event || window.event;
+      this.mouseCords = this.getMousePosition(
+        this.designCanvas.nativeElement,
+        event
+      );
 
-    for (let i = 0; i < this.myBoxes.length; i++) {
-      const box = this.myBoxes[i];
-      if (box.dragging) {
+      let boxesGotMousedOver = false;
+
+      for (let i = 0; i < this.myBoxes.length; i++) {
+        const box = this.myBoxes[i];
         if (
-          this.mouseOutsideBoundaries(
+          !this.mouseOutsideBoundaries(
             this.boxDimensions.width,
             this.boxDimensions.height
           )
         ) {
-          // send back to its last saved position
-          this.myBoxes[i].x = box.previousX;
-          this.myBoxes[i].y = box.previousY;
-          this.myBoxes[i].dragging = false;
-        } else {
-          // save the box in its new position
-          this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
-          this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
-          this.myBoxes[i].previousX =
-            this.mouseCords.x - this.mouseClickOffset.x;
-          this.myBoxes[i].previousY =
-            this.mouseCords.y - this.mouseClickOffset.y;
-          this.myBoxes[i].dragging = false;
+          // check if any of the boxes got moused over
+          if (
+            this.mouseCords.x > box.x &&
+            this.mouseCords.x < box.x + this.boxDimensions.width &&
+            this.mouseCords.y > box.y &&
+            this.mouseCords.y < box.y + this.boxDimensions.height
+          ) {
+            boxesGotMousedOver = true;
+            this.showDeleteBoxButtons = true;
+          }
+          if (box.dragging) {
+            {
+              // move the box with the cursor
+              this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
+              this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
+              // skip checking the other boxes
+              return;
+            }
+          }
         }
-        // skip checking the other boxes
-        return;
       }
+      // only stop showing the delete button if none of the boxes got moused over
+      if (!boxesGotMousedOver) {
+        this.showDeleteBoxButtons = false;
+      }
+    } finally {
+      this.frameChanged = true;
+    }
+  }
+
+  mouseUpHandler(event) {
+    try {
+      event = event || window.event;
+      this.mouseCords = this.getMousePosition(
+        this.designCanvas.nativeElement,
+        event
+      );
+
+      for (let i = 0; i < this.myBoxes.length; i++) {
+        const box = this.myBoxes[i];
+        if (box.dragging) {
+          if (
+            this.mouseOutsideBoundaries(
+              this.boxDimensions.width,
+              this.boxDimensions.height
+            )
+          ) {
+            // send back to its last saved position
+            this.myBoxes[i].x = box.previousX;
+            this.myBoxes[i].y = box.previousY;
+            this.myBoxes[i].dragging = false;
+          } else {
+            // save the box in its new position
+            this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
+            this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
+            this.myBoxes[i].previousX =
+              this.mouseCords.x - this.mouseClickOffset.x;
+            this.myBoxes[i].previousY =
+              this.mouseCords.y - this.mouseClickOffset.y;
+            this.myBoxes[i].dragging = false;
+          }
+          // skip checking the other boxes
+          return;
+        }
+      }
+    } finally {
+      this.frameChanged = true;
     }
   }
 

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -315,7 +315,7 @@ export class FamilyTreeDesignComponent
     draggableBoxRef.instance.touchendEvent.subscribe((value) => {
       this.mouseUpHandler(value);
     });
-    draggableBoxRef.instance.newTextValue.subscribe((value) => {
+    draggableBoxRef.instance.newTextValue.subscribe(() => {
       // We don't actually use the value yet since we can't directly apply it to the element in myBoxes (indexes change)
       // Instead, we update all of the boxes via their refs whenever there is a value change (efficient af am I rite?)
       this.updateBoxRefText();

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -8,6 +8,7 @@ import {
   HostListener,
   Input,
   OnChanges,
+  OnDestroy,
   OnInit,
   Output,
   SimpleChanges,
@@ -44,7 +45,7 @@ import { DraggableBoxComponent } from '../draggable-box/draggable-box.component'
   ],
 })
 export class FamilyTreeDesignComponent
-  implements AfterViewInit, OnInit, OnChanges {
+  implements AfterViewInit, OnInit, OnChanges, OnDestroy {
   // Inputs for design settings
 
   @Input()
@@ -647,6 +648,11 @@ export class FamilyTreeDesignComponent
     }
     this.frameChanged = true;
     this.cdr.detectChanges();
+  }
+
+  ngOnDestroy() {
+    clearInterval(this.timeInterval);
+    clearInterval(this.autosaveInterval);
   }
 
   // handle canvas events

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -102,6 +102,7 @@ export class FamilyTreeDesignComponent
     x: 0,
     y: 0,
   };
+  downEventDelay = false;
 
   // render loop
   timeInterval;
@@ -565,7 +566,6 @@ export class FamilyTreeDesignComponent
 
   saveDesign() {
     console.log('Saving your design...');
-    console.log(this.timeInterval);
     if (
       !this.isDesignValid ||
       this.timeInterval === null ||
@@ -703,6 +703,14 @@ export class FamilyTreeDesignComponent
 
   mouseDownHandler(event) {
     event = event || window.event;
+    // if the mouse down/touchdown event got triggered, don't allow any new down events for 100ms
+    if (this.downEventDelay) {
+      return;
+    } else {
+      this.downEventDelay = true;
+      setTimeout(() => (this.downEventDelay = false), 100);
+    }
+
     this.mouseCords = this.getMousePosition(
       this.designCanvas.nativeElement,
       event

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
@@ -376,6 +376,7 @@ export class FamilyTreeMiniatureComponent
 
   loadDesign() {
     try {
+      this.myBoxes = [];
       // Load the design
       if (this.design === null || this.design === undefined) {
         // Setup default boxes if there is no saved design

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
@@ -35,7 +35,7 @@ export class FamilyTreeMiniatureComponent
   // Inputs for design settings
 
   @Input()
-  design: IFamilyTree;
+  design: IFamilyTree = null;
 
   @Input()
   boxSize = 20;
@@ -91,6 +91,13 @@ export class FamilyTreeMiniatureComponent
       (this.canvasResolution.width / 30) *
       (this.boxSize * this.boxSizeScalingMultiplier),
   };
+
+  // the max chars control how much text can be put into the draggable box
+  // It is propagated to the draggable box input element
+  smallFontMaxChars = 12;
+  largeFontMaxChars = 9;
+  maxCharsPerLine = this.smallFontMaxChars;
+  maxLines = 2;
 
   alert: {
     type: 'success' | 'info' | 'warning' | 'danger';
@@ -191,6 +198,10 @@ export class FamilyTreeMiniatureComponent
     console.log('changes', changes);
     if (this.design !== undefined && this.context !== undefined) {
       this.loadDesign();
+
+      this.maxCharsPerLine = this.design.largeFont
+        ? this.largeFontMaxChars
+        : this.smallFontMaxChars;
     }
   }
 
@@ -249,15 +260,17 @@ export class FamilyTreeMiniatureComponent
       }
       // render the banner
       if (
-        this.bannerDesigns.get(BannerDesignEnum.banner1) !== undefined &&
+        this.bannerDesigns.get(BannerDesignEnum.banner1) !== null &&
         this.bannerDesigns.get(BannerDesignEnum.banner1).complete
       ) {
         if (this.design.banner !== undefined && this.design.banner !== null) {
+          const bannerHeightOffset = 0.96;
           // draw the banner at the bottom middle of the tree
           this.context.drawImage(
             this.bannerDesigns.get(BannerDesignEnum.banner1),
             this.canvasResolution.width / 2 - this.bannerDimensions.width / 2,
-            this.canvasResolution.height - this.bannerDimensions.height,
+            this.canvasResolution.height * bannerHeightOffset -
+              this.bannerDimensions.height,
             this.bannerDimensions.width,
             this.bannerDimensions.height
           );
@@ -267,10 +280,11 @@ export class FamilyTreeMiniatureComponent
           this.context.textBaseline = 'middle';
           this.context.fillText(
             this.design.banner.text,
-            this.canvasResolution.width / 2,
+            this.canvasResolution.width / 1.97,
             // I divide the height by 2.2 because the SVG has no proportions and the text is not exactly in the middle of it...
-            this.canvasResolution.height - this.bannerDimensions.height / 2.2,
-            this.bannerDimensions.width / 3
+            this.canvasResolution.height * bannerHeightOffset -
+              this.bannerDimensions.height / 1.32,
+            this.bannerDimensions.width / 2
           );
         }
       } else {
@@ -291,27 +305,62 @@ export class FamilyTreeMiniatureComponent
           this.boxDimensions.width,
           this.boxDimensions.height
         );
-        const cords = this.getRealCords(this.designCanvas.nativeElement, {
-          x: box.x,
-          y: box.y,
-        });
-        // Update position of the input field to match the box
 
         // Draw the text within the box
         // fancy math to make the value scale well with box size. Source of values: https://www.dcode.fr/function-equation-finder
         // times 5 to account for having different scale
+        // NOTE - can cause performance issues since it occurs on every frame
         const boxTextFontSize =
           (0.0545 * this.boxSize + 0.05) * (this.design.largeFont ? 7 : 5); // in rem
         // TODO: add multi-line support
         this.context.font = `${boxTextFontSize}rem ${this.design.font}`;
         this.context.textAlign = 'center';
         this.context.textBaseline = 'middle';
-        this.context.fillText(
-          this.myBoxes[i].text,
-          this.myBoxes[i].x + this.boxDimensions.width / 2,
-          this.myBoxes[i].y + this.boxDimensions.height / 2,
-          (this.boxDimensions.width / 3) * 2
-        );
+        let line = '';
+        let currentLine = 1;
+        const words = this.myBoxes[i].text
+          .substring(0, this.maxCharsPerLine * this.maxLines)
+          .split(' ');
+        const multiLineText =
+          this.myBoxes[i].text.length > this.maxCharsPerLine;
+        const x = this.myBoxes[i].x + this.boxDimensions.width / 2;
+        let y = this.myBoxes[i].y + this.boxDimensions.height / 2;
+        const lineHeight = (this.boxDimensions.height / 5) * 1;
+        if (multiLineText) {
+          y = this.myBoxes[i].y + (this.boxDimensions.height / 5) * 2;
+        }
+        const formattedWords = [];
+        words.forEach((word) => {
+          do {
+            if (word.length === 0) {
+              break;
+            }
+            if (word.length >= this.maxCharsPerLine) {
+              formattedWords.push(word.substring(0, this.maxCharsPerLine));
+              word = word.substring(this.maxCharsPerLine, word.length);
+            } else {
+              formattedWords.push(word);
+              word = '';
+            }
+          } while (word !== '');
+        });
+        // print out the text
+        for (let j = 0; j < formattedWords.length; j++) {
+          const testLine = line + formattedWords[j] + ' ';
+
+          if (testLine.length - 1 > this.maxCharsPerLine) {
+            currentLine++;
+            if (currentLine > this.maxLines) {
+              break;
+            }
+            this.context.fillText(line, x, y);
+            line = formattedWords[j] + ' ';
+            y += lineHeight;
+          } else {
+            line = testLine;
+          }
+        }
+        this.context.fillText(line, x, y);
       }
     } catch (error) {
       console.error('An error has occurred while drawing the tree', error);


### PR DESCRIPTION
## Goal

<!-- What is this user story supposed to achieve, and what is the context -->

Polish the family tree design and feel

## Keypoints

<!--
    What the user story needs to include in order to be completed.
    The requirements can contain subsections to provide further information.
    Testing (both unit/integration and e2e tests) is implicitly required as per the definition of done. If you don't want them to be a requirement, state so explicitly
 -->
 
 - Limit the fps to 30 (previously was the max your monitor can render) 470735e
 - Only draw the tree when something is changed, otherwise ignore it (big performance saver) 470735e
 - Fix the tree still being drawn after navigating away from the product page 😅 0d57527
 - Fix resetting the design causing duplicate being drawn instead of replacing the old design, lowering the performance 0d57527
 - Fix boxes getting duplicated when design quantity Is changed in the basket 45cbfa7
 - Fix boxes overlapping with default design when viewing immutable design 45cbfa7
 - Fix extra boxes getting created on mobile after clicking to close a box 60d28f6
 - Add multi-line support to miniature view c98eae3
 - Overall optimize the performance of the tree design and miniature
 
 ### Deployment status
 
 Changes are visible on [the staging branch](https://testing.treecreate.dk)
 
 ___
 
 ✅ Closes: #139 
