### PR TITLE
Feat/#141 adjust links for deployments

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/authentication/AuthController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/authentication/AuthController.java
@@ -129,7 +129,7 @@ public class AuthController
 
         try
         {
-            mailService.sendSignupEmail(user.getEmail(), user.getToken().toString(),
+            mailService.sendSignupEmail(user.getEmail(), user.getToken(),
                 localeService.getLocale(null));
         } catch (Exception e)
         {

--- a/apps/api/src/main/java/dk/treecreate/api/mail/MailController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/mail/MailController.java
@@ -45,7 +45,7 @@ public class MailController
 
         try
         {
-            mailService.sendSignupEmail(signupDto.getEmail(), UUID.randomUUID().toString(),
+            mailService.sendSignupEmail(signupDto.getEmail(), UUID.randomUUID(),
                 localeService.getLocale(lang));
         } catch (Exception e)
         {

--- a/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
@@ -49,12 +49,13 @@ public class MailService
         sendMail(to, MailDomain.INFO, subject, context, MailTemplate.SIGNUP);
     }
 
-    public void sendResetPasswordEmail(String to, String token, Locale locale)
+    public void sendResetPasswordEmail(String to, UUID token, Locale locale)
         throws UnsupportedEncodingException, MessagingException
     {
         Context context = new Context(locale);
         context.setVariable("email", to);
-        context.setVariable("token", token);
+        context.setVariable("resetPasswordLink",
+            linkService.generateResetPasswordLink(token, locale));
         String subject = "Reset password";
         sendMail(to, MailDomain.INFO, subject, context, MailTemplate.RESET_PASSWORD);
     }

--- a/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
@@ -1,5 +1,8 @@
 package dk.treecreate.api.mail;
 
+import dk.treecreate.api.order.Order;
+import dk.treecreate.api.utils.LinkService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -7,14 +10,13 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-import dk.treecreate.api.order.Order;
-
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import java.util.UUID;
 
 @Service
 public class MailService
@@ -23,6 +25,9 @@ public class MailService
 
     private final JavaMailSender infoMailSender;
     private final JavaMailSender orderMailSender;
+
+    @Autowired
+    LinkService linkService;
 
     public MailService(TemplateEngine templateEngine,
                        @Qualifier("getJavaInfoMailSender") JavaMailSender infoMailSender,
@@ -33,12 +38,14 @@ public class MailService
         this.orderMailSender = orderMailSender;
     }
 
-    public void sendSignupEmail(String to, String token, Locale locale)
+    public void sendSignupEmail(String to, UUID token, Locale locale)
         throws UnsupportedEncodingException, MessagingException
     {
         Context context = new Context(locale);
         context.setVariable("email", to);
-        context.setVariable("verificationToken", token);
+        context.setVariable("verificationToken", token.toString());
+        context.setVariable("verificationLink",
+            linkService.generateVerificationLink(token, locale));
         String subject = "Welcome to Treecreate";
         sendMail(to, MailDomain.INFO, subject, context, MailTemplate.SIGNUP);
     }

--- a/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
@@ -64,7 +64,8 @@ public class MailService
     {
         Context context = new Context(locale);
         context.setVariable("email", to);
-        context.setVariable("verificationToken", token);
+        context.setVariable("verificationLink",
+            linkService.generateVerificationLink(token, locale));
         String subject = "Treecreate - verify email";
         sendMail(to, MailDomain.INFO, subject, context, MailTemplate.VERIFY_EMAIL);
     }

--- a/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/mail/MailService.java
@@ -43,7 +43,6 @@ public class MailService
     {
         Context context = new Context(locale);
         context.setVariable("email", to);
-        context.setVariable("verificationToken", token.toString());
         context.setVariable("verificationLink",
             linkService.generateVerificationLink(token, locale));
         String subject = "Welcome to Treecreate";
@@ -60,7 +59,7 @@ public class MailService
         sendMail(to, MailDomain.INFO, subject, context, MailTemplate.RESET_PASSWORD);
     }
 
-    public void sendVerificationEmail(String to, String token, Locale locale)
+    public void sendVerificationEmail(String to, UUID token, Locale locale)
         throws UnsupportedEncodingException, MessagingException
     {
         Context context = new Context(locale);

--- a/apps/api/src/main/java/dk/treecreate/api/user/UserController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/user/UserController.java
@@ -159,7 +159,7 @@ public class UserController
         User user = authUserService.getCurrentlyAuthenticatedUser();
         try
         {
-            mailService.sendVerificationEmail(user.getEmail(), user.getToken().toString(),
+            mailService.sendVerificationEmail(user.getEmail(), user.getToken(),
                 localeService.getLocale(lang));
         } catch (Exception e)
         {

--- a/apps/api/src/main/java/dk/treecreate/api/user/UserController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/user/UserController.java
@@ -212,7 +212,7 @@ public class UserController
         }
         try
         {
-            mailService.sendResetPasswordEmail(email, user.getToken().toString(),
+            mailService.sendResetPasswordEmail(email, user.getToken(),
                 localeService.getLocale(lang));
         } catch (Exception e)
         {

--- a/apps/api/src/main/java/dk/treecreate/api/user/UserService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/user/UserService.java
@@ -63,7 +63,7 @@ public class UserService
     {
         System.out.println("Setting to false");
         user.setIsVerified(false);
-        mailService.sendVerificationEmail(user.getEmail(), user.getToken().toString(),
+        mailService.sendVerificationEmail(user.getEmail(), user.getToken(),
             localeService.getLocale(null));
         return user;
     }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -1,0 +1,30 @@
+package dk.treecreate.api.utils;
+
+import dk.treecreate.api.config.CustomPropertiesConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+public class LinkService
+{
+    @Autowired
+    CustomPropertiesConfig customProperties;
+
+    public String generateVerificationLink(UUID token, Locale locale)
+    {
+        String route = "/verification/" + token.toString();
+        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        switch (customProperties.getEnvironment())
+        {
+            case PRODUCTION:
+                return "https://treecreate.dk" + lang + route;
+            case STAGING:
+                return "https://testing.treecreate.dk" + lang + route;
+            default:
+                return "http://localhost:4200" + route;
+        }
+    }
+}

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -13,6 +13,13 @@ public class LinkService
     @Autowired
     CustomPropertiesConfig customProperties;
 
+    /**
+     * Returns link that is used for account verification
+     *
+     * @param token  user-specific UUID token
+     * @param locale what locale the redirected page should be opened in
+     * @return the verification  link with a token
+     */
     public String generateVerificationLink(UUID token, Locale locale)
     {
         String route = "/verification/" + token.toString();
@@ -28,6 +35,13 @@ public class LinkService
         }
     }
 
+    /**
+     * Returns link that is included in the reset password email
+     *
+     * @param token  user-specific UUID token
+     * @param locale what locale the redirected page should be opened in
+     * @return the reset password link with a token
+     */
     public String generateResetPasswordLink(UUID token, Locale locale)
     {
         String route = "/resetPassword/" + token.toString();

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -42,4 +42,49 @@ public class LinkService
                 return "http://localhost:4200" + route;
         }
     }
+
+
+    /**
+     * Returns url that can be assigned to the payment link as the url it should redirect to after a failed/successful payment
+     *
+     * @param environment what environment the app is running in. Affects the domain
+     * @param locale      what locale the redirected page should be opened in
+     * @param successLink whether the link is for a success of payment cancelled redirect
+     * @return the url for redirect
+     */
+    public String generatePaymentRedirectUrl(Environment environment, Locale locale,
+                                             boolean successLink)
+    {
+        String route = successLink ? "/payment/success" : "/payment/cancelled";
+        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        switch (environment)
+        {
+            case PRODUCTION:
+                return "https://treecreate.dk" + lang + route;
+            case STAGING:
+                return "https://testing.treecreate.dk" + lang + route;
+            default:
+                return "http://localhost:4200" + route;
+        }
+    }
+
+    /**
+     * Returns url that can be assigned to the payment and payment link as the callback url
+     *
+     * @param environment what environment the app is running in. Affects the domain
+     * @return the url for redirect
+     */
+    public String generateCallbackUrl(Environment environment)
+    {
+        String route = "/paymentCallback";
+        switch (environment)
+        {
+            case PRODUCTION:
+                return "https://api.treecreate.dk" + route;
+            case STAGING:
+                return "https://api.testing.treecreate.dk" + route;
+            default:
+                return "http://localhost:5000" + route;
+        }
+    }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -2,6 +2,7 @@ package dk.treecreate.api.utils;
 
 import dk.treecreate.api.config.CustomPropertiesConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.Locale;
@@ -23,16 +24,7 @@ public class LinkService
     public String generateVerificationLink(UUID token, Locale locale)
     {
         String route = "/verification/" + token.toString();
-        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
-        switch (customProperties.getEnvironment())
-        {
-            case PRODUCTION:
-                return "https://treecreate.dk" + lang + route;
-            case STAGING:
-                return "https://testing.treecreate.dk" + lang + route;
-            default:
-                return "http://localhost:4200" + route;
-        }
+        return getPath(locale, route, false);
     }
 
     /**
@@ -45,61 +37,32 @@ public class LinkService
     public String generateResetPasswordLink(UUID token, Locale locale)
     {
         String route = "/resetPassword/" + token.toString();
-        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
-        switch (customProperties.getEnvironment())
-        {
-            case PRODUCTION:
-                return "https://treecreate.dk" + lang + route;
-            case STAGING:
-                return "https://testing.treecreate.dk" + lang + route;
-            default:
-                return "http://localhost:4200" + route;
-        }
+        return getPath(locale, route, false);
     }
 
 
     /**
      * Returns url that can be assigned to the payment link as the url it should redirect to after a failed/successful payment
      *
-     * @param environment what environment the app is running in. Affects the domain
      * @param locale      what locale the redirected page should be opened in
      * @param successLink whether the link is for a success of payment cancelled redirect
      * @return the url for redirect
      */
-    public String generatePaymentRedirectUrl(Environment environment, Locale locale,
-                                             boolean successLink)
+    public String generatePaymentRedirectUrl(Locale locale, boolean successLink)
     {
         String route = successLink ? "/payment/success" : "/payment/cancelled";
-        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
-        switch (environment)
-        {
-            case PRODUCTION:
-                return "https://treecreate.dk" + lang + route;
-            case STAGING:
-                return "https://testing.treecreate.dk" + lang + route;
-            default:
-                return "http://localhost:4200" + route;
-        }
+        return getPath(locale, route, false);
     }
 
     /**
      * Returns url that can be assigned to the payment and payment link as the callback url
      *
-     * @param environment what environment the app is running in. Affects the domain
      * @return the url for redirect
      */
-    public String generateCallbackUrl(Environment environment)
+    public String generateCallbackUrl()
     {
         String route = "/paymentCallback";
-        switch (environment)
-        {
-            case PRODUCTION:
-                return "https://api.treecreate.dk" + route;
-            case STAGING:
-                return "https://api.testing.treecreate.dk" + route;
-            default:
-                return "http://localhost:5000" + route;
-        }
+        return getPath(null, route, true);
     }
 
     /**
@@ -112,15 +75,25 @@ public class LinkService
     public String generateNewsletterUnsubscribeLink(UUID newsletterId, Locale locale)
     {
         String route = "/newsletter/unsubscribe/" + newsletterId.toString();
-        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        return getPath(locale, route, false);
+    }
+
+    // private method for combining the route, environment and locale into a link
+    private String getPath(@Nullable Locale locale, String route, boolean isApi)
+    {
+        String lang = "";
+        if (!isApi)
+        {
+            lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        }
         switch (customProperties.getEnvironment())
         {
             case PRODUCTION:
-                return "https://treecreate.dk" + lang + route;
+                return "https://" + (isApi ? "api." : "") + "treecreate.dk" + lang + route;
             case STAGING:
-                return "https://testing.treecreate.dk" + lang + route;
+                return "https://" + (isApi ? "api." : "") + "testing.treecreate.dk" + lang + route;
             default:
-                return "http://localhost:4200" + route;
+                return "http://localhost:" + (isApi ? "5000" : "4200") + route;
         }
     }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -101,4 +101,26 @@ public class LinkService
                 return "http://localhost:5000" + route;
         }
     }
+
+    /**
+     * Returns link that is included in the newsletter emails
+     *
+     * @param newsletterId id of the newsletter entry
+     * @param locale       what locale the redirected page should be opened in
+     * @return the newsletter unsubscribe link with a newsletterId
+     */
+    public String generateNewsletterUnsubscribeLink(UUID newsletterId, Locale locale)
+    {
+        String route = "/newsletter/unsubscribe/" + newsletterId.toString();
+        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        switch (customProperties.getEnvironment())
+        {
+            case PRODUCTION:
+                return "https://treecreate.dk" + lang + route;
+            case STAGING:
+                return "https://testing.treecreate.dk" + lang + route;
+            default:
+                return "http://localhost:4200" + route;
+        }
+    }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -27,4 +27,19 @@ public class LinkService
                 return "http://localhost:4200" + route;
         }
     }
+
+    public String generateResetPasswordLink(UUID token, Locale locale)
+    {
+        String route = "/resetPassword/" + token.toString();
+        String lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/dk";
+        switch (customProperties.getEnvironment())
+        {
+            case PRODUCTION:
+                return "https://treecreate.dk" + lang + route;
+            case STAGING:
+                return "https://testing.treecreate.dk" + lang + route;
+            default:
+                return "http://localhost:4200" + route;
+        }
+    }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
@@ -67,8 +67,7 @@ public class QuickpayService
             .uri(new URI(quickpayApiUrl + "/payments"))
             .headers(headers -> headers.setBasicAuth("", apiKey))
             .header("Accept-Version", "v10")
-            .header("QuickPay-Callback-Url",
-                linkService.generateCallbackUrl(customProperties.getEnvironment()))
+            .header("QuickPay-Callback-Url", linkService.generateCallbackUrl())
             .body(BodyInserters.fromValue(payment))
             .retrieve()
             .bodyToMono(Payment.class)
@@ -114,12 +113,10 @@ public class QuickpayService
 
         // assign the payment redirect urls
         createPaymentLinkRequest.continue_url =
-            linkService.generatePaymentRedirectUrl(customProperties.getEnvironment(), locale, true);
+            linkService.generatePaymentRedirectUrl(locale, true);
         createPaymentLinkRequest.cancel_url =
-            linkService.generatePaymentRedirectUrl(customProperties.getEnvironment(), locale,
-                false);
-        createPaymentLinkRequest.callback_url =
-            linkService.generateCallbackUrl(customProperties.getEnvironment());
+            linkService.generatePaymentRedirectUrl(locale, false);
+        createPaymentLinkRequest.callback_url = linkService.generateCallbackUrl();
 
         // TODO - add proper error handling of the response
         WebClient client = WebClient.create();
@@ -127,8 +124,7 @@ public class QuickpayService
             .uri(new URI(quickpayApiUrl + "/payments/" + paymentId + "/link"))
             .headers(headers -> headers.setBasicAuth("", apiKey))
             .header("Accept-Version", "v10")
-            .header("QuickPay-Callback-Url",
-                linkService.generateCallbackUrl(customProperties.getEnvironment()))
+            .header("QuickPay-Callback-Url", linkService.generateCallbackUrl())
             .body(BodyInserters.fromValue(createPaymentLinkRequest))
             .retrieve()
             .bodyToMono(CreatePaymentLinkResponse.class)

--- a/apps/api/src/main/resources/templates/emails/reset-password.html
+++ b/apps/api/src/main/resources/templates/emails/reset-password.html
@@ -519,7 +519,7 @@
                                                             >
                                                                 <!-- TODO: Make the reset button not show the url in the button -->
                                                                 <a
-                                                                    th:href="'treecreate.dk/resetPassword/' + ${token}"
+                                                                    th:href="${resetPasswordLink}"
                                                                     th:text="#{reset.password.button}"
                                                                     style="
                                                                         color: white;

--- a/apps/api/src/main/resources/templates/emails/signup.html
+++ b/apps/api/src/main/resources/templates/emails/signup.html
@@ -535,7 +535,7 @@
                                                             >
                                                                 <!-- TODO: Make the reset button not show the url in the button -->
                                                                 <a
-                                                                    th:href="'treecreate.dk/verification/' + ${verificationToken}"
+                                                                    th:href="${verificationLink}"
                                                                     th:text="#{signup.verify.email}"
                                                                     style="
                                                                         color: white;

--- a/apps/api/src/main/resources/templates/emails/verify-email.html
+++ b/apps/api/src/main/resources/templates/emails/verify-email.html
@@ -535,7 +535,7 @@
                                                             >
                                                                 <!-- TODO: Make the reset button not show the url in the button -->
                                                                 <a
-                                                                    th:href="'treecreate.dk/verification/' + ${verificationToken}"
+                                                                    th:href="${verificationLink}"
                                                                     th:text="#{signup.verify.email}"
                                                                     style="
                                                                         color: white;

--- a/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
@@ -177,7 +177,7 @@ class AuthControllerTests
             java.util.Optional.of(new Role(ERole.ROLE_USER)));
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         Mockito.doNothing().when(mailService)
-            .sendSignupEmail(user.getEmail(), user.getToken().toString(), new Locale("dk"));
+            .sendSignupEmail(user.getEmail(), user.getToken(), new Locale("dk"));
 
         mvc.perform(post("/auth/signup")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
@@ -230,7 +230,7 @@ class AuthControllerTests
 
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         Mockito.doNothing().when(mailService)
-            .sendVerificationEmail(user.getEmail(), user.getToken().toString(), new Locale("dk"));
+            .sendVerificationEmail(user.getEmail(), user.getToken(), new Locale("dk"));
 
         mvc.perform(post("/auth/signup")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/api/src/test/java/dk/treecreate/api/mail/MailControllerTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/mail/MailControllerTest.java
@@ -5,6 +5,7 @@ import dk.treecreate.api.authentication.jwt.AuthEntryPointJwt;
 import dk.treecreate.api.authentication.jwt.JwtUtils;
 import dk.treecreate.api.authentication.services.UserDetailsServiceImpl;
 import dk.treecreate.api.mail.dto.SignupDto;
+import dk.treecreate.api.utils.LinkService;
 import dk.treecreate.api.utils.LocaleService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Locale;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,6 +51,8 @@ class MailControllerTest
     private JwtUtils jwtUtils;
     @MockBean
     private LocaleService localeService;
+    @MockBean
+    private LinkService linkService;
 
 
     //region /signup endpoint tests
@@ -92,7 +96,7 @@ class MailControllerTest
         Mockito.when(mailService.isValidEmail(email)).thenReturn(true);
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         Mockito.doThrow(UnsupportedEncodingException.class).when(mailService)
-            .sendSignupEmail(anyString(), anyString(), any(Locale.class));
+            .sendSignupEmail(anyString(), any(UUID.class), any(Locale.class));
 
         mvc.perform(post("/mail/signup").content(TestUtilsService.asJsonString(params))
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isInternalServerError());
@@ -140,7 +144,7 @@ class MailControllerTest
         Mockito.when(mailService.isValidEmail(email)).thenReturn(true);
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         doThrow(UnsupportedEncodingException.class).when(mailService)
-            .sendSignupEmail(anyString(), anyString(), any(Locale.class));
+            .sendSignupEmail(anyString(), any(UUID.class), any(Locale.class));
 
         mvc.perform(post("/mail/signup").content(TestUtilsService.asJsonString(params))
                 .contentType(MediaType.APPLICATION_JSON))

--- a/apps/api/src/test/java/dk/treecreate/api/users/UserControllerTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/users/UserControllerTests.java
@@ -219,8 +219,8 @@ class UserControllerTests
             Mockito.when(userRepository.save(user)).thenReturn(user);
 
             mvc.perform(put("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(updateUserRequest)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtilsService.asJsonString(updateUserRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().json(TestUtilsService.asJsonString(user)));
         }
@@ -246,8 +246,8 @@ class UserControllerTests
             Mockito.when(userRepository.save(user)).thenReturn(user);
 
             mvc.perform(put("/users/" + userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(updateUserRequest)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtilsService.asJsonString(updateUserRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().json(TestUtilsService.asJsonString(user)));
         }
@@ -265,8 +265,8 @@ class UserControllerTests
             updateUserRequest.setEmail("invalid format");
 
             mvc.perform(put("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(updateUserRequest)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtilsService.asJsonString(updateUserRequest)))
                 .andExpect(status().isBadRequest());
         }
 
@@ -291,8 +291,8 @@ class UserControllerTests
                 .thenReturn(true);
 
             mvc.perform(put("/users/" + userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(updateUserRequest)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtilsService.asJsonString(updateUserRequest)))
                 .andExpect(status().isBadRequest());
         }
 
@@ -309,8 +309,8 @@ class UserControllerTests
             updateUserRequest.setPhoneNumber("12345678901234567890"); // the limit is 15
 
             mvc.perform(put("/users/" + userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(updateUserRequest)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtilsService.asJsonString(updateUserRequest)))
                 .andExpect(status().isBadRequest());
         }
     }
@@ -364,8 +364,7 @@ class UserControllerTests
                 .thenReturn(user);
             Mockito.when(localeService.getLocale(any())).thenReturn(new Locale("dk"));
             Mockito.doNothing().when(mailService)
-                .sendVerificationEmail(anyString(), anyString(),
-                    any(Locale.class));
+                .sendVerificationEmail(anyString(), any(UUID.class), any(Locale.class));
             mvc.perform(get("/users/verification/email/me"))
                 .andExpect(status().isNoContent());
         }

--- a/apps/api/src/test/java/dk/treecreate/api/users/UserServiceTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/users/UserServiceTests.java
@@ -198,7 +198,7 @@ class UserServiceTests
         Mockito.when(userRepository.existsByEmail(updateUserRequest.getEmail())).thenReturn(false);
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         Mockito.doNothing().when(mailService)
-            .sendVerificationEmail(user.getEmail(), user.getToken().toString(), new Locale("dk"));
+            .sendVerificationEmail(user.getEmail(), user.getToken(), new Locale("dk"));
 
         assertEquals(user, userService.updateUser(updateUserRequest, baseUser));
     }
@@ -227,7 +227,7 @@ class UserServiceTests
         Mockito.when(userRepository.existsByEmail(updateUserRequest.getEmail())).thenReturn(false);
         Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
         Mockito.doNothing().when(mailService)
-            .sendVerificationEmail(user.getEmail(), user.getToken().toString(), new Locale("dk"));
+            .sendVerificationEmail(user.getEmail(), user.getToken(), new Locale("dk"));
 
         assertEquals(user, userService.updateUser(updateUserRequest, baseUser));
     }

--- a/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
@@ -1,13 +1,17 @@
 package dk.treecreate.api.utils;
 
+import dk.treecreate.api.config.CustomPropertiesConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Locale;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,6 +21,8 @@ public class LinkServiceTest
 {
     @Autowired
     LinkService linkService;
+    @MockBean
+    CustomPropertiesConfig customProperties;
 
     private static Stream<Arguments> generatePaymentRedirectUrlArguments()
     {
@@ -54,6 +60,83 @@ public class LinkServiceTest
                                     boolean successLink, String expectedUrl)
     {
         assertEquals(linkService.generatePaymentRedirectUrl(environment, locale, successLink),
+            expectedUrl);
+    }
+
+    private static Stream<Arguments> generateCallbackUrlArguments()
+    {
+        return Stream.of(
+            Arguments.of(Environment.DEVELOPMENT,
+                "http://localhost:5000/paymentCallback"),
+            Arguments.of(Environment.STAGING,
+                "https://api.testing.treecreate.dk/paymentCallback"),
+            Arguments.of(Environment.PRODUCTION,
+                "https://api.treecreate.dk/paymentCallback"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateCallbackUrlArguments")
+    @DisplayName("generateCallbackUrl() returns a correctly structured callback url")
+    void generateCallbackUrl(Environment environment, String expectedUrl)
+    {
+        assertEquals(linkService.generateCallbackUrl(environment), expectedUrl);
+    }
+
+    private static Stream<Arguments> generateVerificationLinkArguments()
+    {
+        return Stream.of(
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.DEVELOPMENT,
+                "http://localhost:4200/verification/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.STAGING,
+                "https://testing.treecreate.dk/en-US/verification/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.PRODUCTION,
+                "https://treecreate.dk/en-US/verification/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.DEVELOPMENT,
+                "http://localhost:4200/verification/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.STAGING,
+                "https://testing.treecreate.dk/dk/verification/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.PRODUCTION,
+                "https://treecreate.dk/dk/verification/00000000-0000-0000-0000-000000000000"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateVerificationLinkArguments")
+    @DisplayName("generateVerificationLink() returns a correctly structured verification link")
+    void generateVerificationLink(UUID token, Locale locale, Environment environment,
+                                  String expectedUrl)
+    {
+        Mockito.when(customProperties.getEnvironment()).thenReturn(environment);
+
+        assertEquals(linkService.generateVerificationLink(token, locale),
+            expectedUrl);
+    }
+
+    private static Stream<Arguments> generateResetPasswordLinkArguments()
+    {
+        return Stream.of(
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.DEVELOPMENT,
+                "http://localhost:4200/resetPassword/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.STAGING,
+                "https://testing.treecreate.dk/en-US/resetPassword/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.PRODUCTION,
+                "https://treecreate.dk/en-US/resetPassword/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.DEVELOPMENT,
+                "http://localhost:4200/resetPassword/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.STAGING,
+                "https://testing.treecreate.dk/dk/resetPassword/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.PRODUCTION,
+                "https://treecreate.dk/dk/resetPassword/00000000-0000-0000-0000-000000000000"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateResetPasswordLinkArguments")
+    @DisplayName("generateResetPasswordLink() returns a correctly structured reset password link")
+    void generateResetPasswordLink(UUID token, Locale locale, Environment environment,
+                                   String expectedUrl)
+    {
+        Mockito.when(customProperties.getEnvironment()).thenReturn(environment);
+
+        assertEquals(linkService.generateResetPasswordLink(token, locale),
             expectedUrl);
     }
 }

--- a/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
@@ -59,7 +59,9 @@ public class LinkServiceTest
     void generatePaymentRedirectUrl(Environment environment, Locale locale,
                                     boolean successLink, String expectedUrl)
     {
-        assertEquals(linkService.generatePaymentRedirectUrl(environment, locale, successLink),
+        Mockito.when(customProperties.getEnvironment()).thenReturn(environment);
+
+        assertEquals(linkService.generatePaymentRedirectUrl(locale, successLink),
             expectedUrl);
     }
 
@@ -79,7 +81,9 @@ public class LinkServiceTest
     @DisplayName("generateCallbackUrl() returns a correctly structured callback url")
     void generateCallbackUrl(Environment environment, String expectedUrl)
     {
-        assertEquals(linkService.generateCallbackUrl(environment), expectedUrl);
+        Mockito.when(customProperties.getEnvironment()).thenReturn(environment);
+
+        assertEquals(linkService.generateCallbackUrl(), expectedUrl);
     }
 
     private static Stream<Arguments> generateVerificationLinkArguments()

--- a/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
@@ -139,4 +139,35 @@ public class LinkServiceTest
         assertEquals(linkService.generateResetPasswordLink(token, locale),
             expectedUrl);
     }
+
+    private static Stream<Arguments> generateNewsletterUnsubscribeLinkArguments()
+    {
+        return Stream.of(
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.DEVELOPMENT,
+                "http://localhost:4200/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.STAGING,
+                "https://testing.treecreate.dk/en-US/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), Locale.ENGLISH, Environment.PRODUCTION,
+                "https://treecreate.dk/en-US/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.DEVELOPMENT,
+                "http://localhost:4200/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.STAGING,
+                "https://testing.treecreate.dk/dk/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            Arguments.of(new UUID(0, 0), new Locale("dk"), Environment.PRODUCTION,
+                "https://treecreate.dk/dk/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateNewsletterUnsubscribeLinkArguments")
+    @DisplayName(
+        "generateNewsletterUnsubscribeLink() returns a correctly structured newsletter unsubscribe link")
+    void generateNewsletterUnsubscribeLink(UUID newsletterId, Locale locale,
+                                           Environment environment,
+                                           String expectedUrl)
+    {
+        Mockito.when(customProperties.getEnvironment()).thenReturn(environment);
+
+        assertEquals(linkService.generateNewsletterUnsubscribeLink(newsletterId, locale),
+            expectedUrl);
+    }
 }

--- a/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
@@ -1,0 +1,59 @@
+package dk.treecreate.api.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class LinkServiceTest
+{
+    @Autowired
+    LinkService linkService;
+
+    private static Stream<Arguments> generatePaymentRedirectUrlArguments()
+    {
+        return Stream.of(
+            Arguments.of(Environment.DEVELOPMENT, Locale.ENGLISH, true,
+                "http://localhost:4200/payment/success"),
+            Arguments.of(Environment.DEVELOPMENT, new Locale("dk"), true,
+                "http://localhost:4200/payment/success"),
+            Arguments.of(Environment.DEVELOPMENT, Locale.ENGLISH, false,
+                "http://localhost:4200/payment/cancelled"),
+            Arguments.of(Environment.DEVELOPMENT, new Locale("dk"), false,
+                "http://localhost:4200/payment/cancelled"),
+            Arguments.of(Environment.STAGING, Locale.ENGLISH, true,
+                "https://testing.treecreate.dk/en-US/payment/success"),
+            Arguments.of(Environment.STAGING, new Locale("dk"), true,
+                "https://testing.treecreate.dk/dk/payment/success"),
+            Arguments.of(Environment.STAGING, Locale.ENGLISH, false,
+                "https://testing.treecreate.dk/en-US/payment/cancelled"),
+            Arguments.of(Environment.STAGING, new Locale("dk"), false,
+                "https://testing.treecreate.dk/dk/payment/cancelled"),
+            Arguments.of(Environment.PRODUCTION, Locale.ENGLISH, true,
+                "https://treecreate.dk/en-US/payment/success"),
+            Arguments.of(Environment.PRODUCTION, new Locale("dk"), true,
+                "https://treecreate.dk/dk/payment/success"),
+            Arguments.of(Environment.PRODUCTION, Locale.ENGLISH, false,
+                "https://treecreate.dk/en-US/payment/cancelled"),
+            Arguments.of(Environment.PRODUCTION, new Locale("dk"), false,
+                "https://treecreate.dk/dk/payment/cancelled"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("generatePaymentRedirectUrlArguments")
+    @DisplayName("generatePaymentRedirectUrl() returns a correctly structured redirect url")
+    void generatePaymentRedirectUrl(Environment environment, Locale locale,
+                                    boolean successLink, String expectedUrl)
+    {
+        assertEquals(linkService.generatePaymentRedirectUrl(environment, locale, successLink),
+            expectedUrl);
+    }
+}

--- a/apps/api/src/test/java/dk/treecreate/api/utils/QuickpayServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/QuickpayServiceTest.java
@@ -7,10 +7,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Locale;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -18,8 +16,6 @@ class QuickpayServiceTest
 {
     @Autowired
     QuickpayService quickpayService;
-    @Autowired
-    LinkService linkService;
 
     private static Stream<Arguments> createOrderIdArguments()
     {
@@ -38,44 +34,4 @@ class QuickpayServiceTest
     {
         assertTrue(quickpayService.createOrderId(email, environment).contains(expectedPrefix));
     }
-
-    private static Stream<Arguments> generatePaymentRedirectUrlArguments()
-    {
-        return Stream.of(
-            Arguments.of(Environment.DEVELOPMENT, Locale.ENGLISH, true,
-                "http://localhost:4200/payment/success"),
-            Arguments.of(Environment.DEVELOPMENT, new Locale("dk"), true,
-                "http://localhost:4200/payment/success"),
-            Arguments.of(Environment.DEVELOPMENT, Locale.ENGLISH, false,
-                "http://localhost:4200/payment/cancelled"),
-            Arguments.of(Environment.DEVELOPMENT, new Locale("dk"), false,
-                "http://localhost:4200/payment/cancelled"),
-            Arguments.of(Environment.STAGING, Locale.ENGLISH, true,
-                "https://testing.treecreate.dk/en-US/payment/success"),
-            Arguments.of(Environment.STAGING, new Locale("dk"), true,
-                "https://testing.treecreate.dk/dk/payment/success"),
-            Arguments.of(Environment.STAGING, Locale.ENGLISH, false,
-                "https://testing.treecreate.dk/en-US/payment/cancelled"),
-            Arguments.of(Environment.STAGING, new Locale("dk"), false,
-                "https://testing.treecreate.dk/dk/payment/cancelled"),
-            Arguments.of(Environment.PRODUCTION, Locale.ENGLISH, true,
-                "https://treecreate.dk/en-US/payment/success"),
-            Arguments.of(Environment.PRODUCTION, new Locale("dk"), true,
-                "https://treecreate.dk/dk/payment/success"),
-            Arguments.of(Environment.PRODUCTION, Locale.ENGLISH, false,
-                "https://treecreate.dk/en-US/payment/cancelled"),
-            Arguments.of(Environment.PRODUCTION, new Locale("dk"), false,
-                "https://treecreate.dk/dk/payment/cancelled"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("generatePaymentRedirectUrlArguments")
-    @DisplayName("generatePaymentRedirectUrl() returns a correctly structured redirect url")
-    void generatePaymentRedirectUrl(Environment environment, Locale locale,
-                                    boolean successLink, String expectedUrl)
-    {
-        assertEquals(linkService.generatePaymentRedirectUrl(environment, locale, successLink),
-            expectedUrl);
-    }
-
 }

--- a/apps/api/src/test/java/dk/treecreate/api/utils/QuickpayServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/QuickpayServiceTest.java
@@ -18,6 +18,8 @@ class QuickpayServiceTest
 {
     @Autowired
     QuickpayService quickpayService;
+    @Autowired
+    LinkService linkService;
 
     private static Stream<Arguments> createOrderIdArguments()
     {
@@ -72,7 +74,7 @@ class QuickpayServiceTest
     void generatePaymentRedirectUrl(Environment environment, Locale locale,
                                     boolean successLink, String expectedUrl)
     {
-        assertEquals(quickpayService.generatePaymentRedirectUrl(environment, locale, successLink),
+        assertEquals(linkService.generatePaymentRedirectUrl(environment, locale, successLink),
             expectedUrl);
     }
 


### PR DESCRIPTION
## Goal

<!-- What is this user story supposed to achieve, and what is the context -->

Verification, Reset password and Unsubscribe links should point to the correct URL depending on the environment

## Keypoints

 - If localhost aka DEVELOPMENT, the links should point to `http://localhost:4200`
 - If deployed testing aka STAGING, the links should point to `https://testing.treecreate.dk`
 - If deployed production aka PRODUCTION, the links should point to `https://treecreate.dk`
 - Extracted existing link generation methods to `Utils/ LinkService`
 - Added tests for all LinkService methods
 - Added Javadoc for all LinkService methods
 - Adjusted existing links in email templates to use the new links
 - Added link generation for unsubscribe email, but didn't connect it to mailService or a template because they don't exist
 - 
 ### Deployment status
 
 Changes are visible on [the staging branch](https://testing.treecreate.dk)
___
✅ Closes: #141 