### PR TITLE
Fix/#150 fix issues with tree design

### DIFF
--- a/apps/webstore/src/app/pages/product/product.component.ts
+++ b/apps/webstore/src/app/pages/product/product.component.ts
@@ -198,13 +198,17 @@ export class ProductComponent implements OnInit {
       LocalStorageVars.designFamilyTree
     ).value;
     // don't persist the design if the user is not logged in
-    if (!this.isLoggedIn || !persist) {
+    if (!this.isLoggedIn) {
       this.toastService.showAlert(
         'Your design has been saved to your session. If you want to save it permanently, please create an account first.',
         'Dit design er bleven gemt i din browser. Hvis du vil gemme det permanent skal du oprette en konto først.',
         'success',
         10000
       );
+      return;
+    }
+    // Don't save the tree to the collection/database. Used in combindation with the addToBasketModal
+    if (!persist) {
       return;
     }
     const queryParams = this.route.snapshot.queryParams;
@@ -256,6 +260,11 @@ export class ProductComponent implements OnInit {
               'success',
               5000
             );
+            this.router.navigate([], {
+              relativeTo: this.route,
+              queryParams: { designId: result.designId },
+              queryParamsHandling: 'merge', // remove to replace all query params by provided
+            });
           },
           (error: HttpErrorResponse) => {
             console.error('Failed to save design', error);

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -319,6 +319,7 @@ export class FamilyTreeDesignComponent
       // We don't actually use the value yet since we can't directly apply it to the element in myBoxes (indexes change)
       // Instead, we update all of the boxes via their refs whenever there is a value change (efficient af am I rite?)
       this.updateBoxRefText();
+      this.frameChanged = true;
     });
     draggableBoxRef.instance.text = newBox.text;
     draggableBoxRef.instance.zIndex = this.myBoxes.length;


### PR DESCRIPTION
- When `save` button is pressed, the designId is added to the URL so the viewer starts editing the newly saved tree
- The design box change should automatically cause drawing of a new frame instead of making it look like the input is lagging
___
✅ Closes: #150 