### PR TITLE
feat/#166 fix nginx locale not matching local storage

### DIFF
--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
+import { LocaleType, LocalStorageVars } from '@models';
 import { environment } from '../environments/environment';
+import { LocalStorageService } from './shared/services/local-storage';
 
 // Google analytics-specific syntax
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -12,7 +14,12 @@ declare let gtag: Function;
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
-  constructor(public router: Router) {
+  title = 'Treecreate';
+
+  constructor(
+    public router: Router,
+    private localStorageService: LocalStorageService
+  ) {
     //Google analytics
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationEnd) {
@@ -28,7 +35,23 @@ export class AppComponent {
         }
       }
     });
-  }
 
-  title = 'Treecreate';
+    this.router.events.subscribe(() => {
+      const locale = this.localStorageService
+        .getItem<LocaleType>(LocalStorageVars.locale)
+        .getValue();
+      // if the website is deployed the url has locale in it and has to be adjusted to match local storage
+      if (
+        window.location.href.includes('/en-US/') &&
+        locale === LocaleType.dk
+      ) {
+        window.location.href = window.location.href.replace('en-US', 'dk');
+      } else if (
+        window.location.href.includes('/dk/') &&
+        locale === LocaleType.en
+      ) {
+        window.location.href = window.location.href.replace('dk', 'en-US');
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Goal

<!-- What is this user story supposed to achieve, and what is the context -->

NGINX default locale should be the same as frontend locale (DK)

## Requirements

<!--
    What the user story needs to include in order to be completed.
    The requirements can contain subsections to provide further information.
    Testing (both unit/integration and e2e tests) is implicitly required as per the definition of done. If you don't want them to be a requirement, state so explicitly
 -->
 
 - When treecreate is accessed, the URL and the contents should match the set locale
 - The default locale should be danish
 
 ---
 ✅ Closes: #166 

