### PR TITLE
Feat/#72 remove ability to register as any role

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/authentication/AuthController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/authentication/AuthController.java
@@ -70,7 +70,6 @@ public class AuthController
             .authenticateUser(loginRequest.getEmail(), loginRequest.getPassword()));
     }
 
-    // TODO: remove ability for any user to register as any role.
     @PostMapping("/signup")
     @Operation(summary = "Register a new user")
     @ApiResponses(value = {
@@ -92,38 +91,12 @@ public class AuthController
             signUpRequest.getEmail(),
             encoder.encode(signUpRequest.getPassword()));
 
-        Set<String> strRoles = signUpRequest.getRoles();
         Set<Role> roles = new HashSet<>();
 
-        if (strRoles == null)
-        {
-            Role userRole = roleRepository.findByName(ERole.ROLE_USER)
-                .orElseThrow(() -> new RuntimeException(ROLE_NOT_FOUND_ERROR_MESSAGE));
-            roles.add(userRole);
-        } else
-        {
-            strRoles.forEach(role -> {
-                switch (role)
-                {
-                    case "ROLE_ADMIN":
-                        Role adminRole = roleRepository.findByName(ERole.ROLE_ADMIN)
-                            .orElseThrow(() -> new RuntimeException(ROLE_NOT_FOUND_ERROR_MESSAGE));
-                        roles.add(adminRole);
+        Role userRole = roleRepository.findByName(ERole.ROLE_USER)
+            .orElseThrow(() -> new RuntimeException(ROLE_NOT_FOUND_ERROR_MESSAGE));
+        roles.add(userRole);
 
-                        break;
-                    case "ROLE_DEVELOPER":
-                        Role developerRole = roleRepository.findByName(ERole.ROLE_DEVELOPER)
-                            .orElseThrow(() -> new RuntimeException(ROLE_NOT_FOUND_ERROR_MESSAGE));
-                        roles.add(developerRole);
-
-                        break;
-                    default:
-                        Role userRole = roleRepository.findByName(ERole.ROLE_USER)
-                            .orElseThrow(() -> new RuntimeException(ROLE_NOT_FOUND_ERROR_MESSAGE));
-                        roles.add(userRole);
-                }
-            });
-        }
         user.setRoles(roles);
         userRepository.save(user);
 

--- a/apps/api/src/main/java/dk/treecreate/api/authentication/dto/request/SignupRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/authentication/dto/request/SignupRequest.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.util.Set;
 
 public class SignupRequest
 {
@@ -19,10 +18,6 @@ public class SignupRequest
     @Size(min = 6, max = 40)
     @ApiModelProperty(example = "abcDEF123", required = true)
     private String password;
-
-    @ApiModelProperty(notes = "A list of roles the user can have",
-        example = "[\"ROLE_USED\", \"ROLE_DEVELOPER\", \"ROLE_ADMIN\"]", required = false)
-    private Set<String> roles;
 
     public String getEmail()
     {
@@ -42,15 +37,5 @@ public class SignupRequest
     public void setPassword(String password)
     {
         this.password = password;
-    }
-
-    public Set<String> getRoles()
-    {
-        return this.roles;
-    }
-
-    public void setRoles(Set<String> roles)
-    {
-        this.roles = roles;
     }
 }

--- a/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
+++ b/apps/api/src/test/java/dk/treecreate/api/authentication/AuthControllerTests.java
@@ -56,7 +56,7 @@ class AuthControllerTests
     void signinReturnsBadRequestOnInvalidBody() throws Exception
     {
         mvc.perform(post("/auth/signin")
-                .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest());
     }
 
@@ -83,8 +83,8 @@ class AuthControllerTests
             java.util.Optional.of(user));
 
         mvc.perform(post("/auth/signin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(loginRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtilsService.asJsonString(loginRequest)))
             .andExpect(status().isUnauthorized());
     }
 
@@ -115,8 +115,8 @@ class AuthControllerTests
             java.util.Optional.of(user));
 
         mvc.perform(post("/auth/signin")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(loginRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtilsService.asJsonString(loginRequest)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("userId", is(user.getUserId().toString())))
             .andExpect(jsonPath("email", is(user.getEmail())))
@@ -131,7 +131,7 @@ class AuthControllerTests
     void signupReturnsBadRequestOnInvalidBody() throws Exception
     {
         mvc.perform(post("/auth/signup")
-                .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest());
     }
 
@@ -146,8 +146,8 @@ class AuthControllerTests
         Mockito.when(userRepository.existsByEmail(signupRequest.getEmail())).thenReturn(true);
 
         mvc.perform(post("/auth/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(signupRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtilsService.asJsonString(signupRequest)))
             .andExpect(status().isBadRequest());
     }
 
@@ -180,8 +180,8 @@ class AuthControllerTests
             .sendSignupEmail(user.getEmail(), user.getToken(), new Locale("dk"));
 
         mvc.perform(post("/auth/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(signupRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtilsService.asJsonString(signupRequest)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("userId", is(user.getUserId().toString())))
             .andExpect(jsonPath("email", is(user.getEmail())))
@@ -190,56 +190,4 @@ class AuthControllerTests
             .andExpect(jsonPath("accessToken", is(notNullValue())));
     }
     //endregion
-
-    @Test
-    @DisplayName("/auth/signup endpoint correctly creates a new user with specified roles")
-    void signupCorrectlyCreatesNewUserWithSpecifiedRoles() throws Exception
-    {
-        Set<Role> roles = new HashSet<>();
-        roles.add(new Role(ERole.ROLE_USER));
-        roles.add(new Role(ERole.ROLE_DEVELOPER));
-        roles.add(new Role(ERole.ROLE_ADMIN));
-
-        Set<String> strRoles = new HashSet<>();
-        strRoles.add("ROLE_USER");
-        strRoles.add("ROLE_DEVELOPER");
-        strRoles.add("ROLE_ADMIN");
-
-        SignupRequest signupRequest = new SignupRequest();
-        signupRequest.setEmail("test@treecreate.dk");
-        signupRequest.setPassword("abcDEF123");
-        signupRequest.setRoles(strRoles);
-
-        User user = new User();
-        user.setUserId(UUID.fromString("c0a80121-7ab6-1787-817a-b69966240000"));
-        user.setEmail(signupRequest.getEmail());
-        user.setUsername(signupRequest.getEmail());
-        user.setPassword(
-            "$2a$10$ZPr0bH6kt2EnjkkRk1TEH.Mnyo/GRlfjBj/60gFuLI/BnauOx2p62"); // hashed version of "abcDEF123"
-        user.setRoles(roles);
-
-        Mockito.when(userRepository.save(user)).thenReturn(user);
-        Mockito.when(userRepository.findByEmail(signupRequest.getEmail())).thenReturn(
-            java.util.Optional.of(user));
-        Mockito.when(roleRepository.findByName(ERole.ROLE_USER)).thenReturn(
-            java.util.Optional.of(new Role(ERole.ROLE_USER)));
-        Mockito.when(roleRepository.findByName(ERole.ROLE_DEVELOPER)).thenReturn(
-            java.util.Optional.of(new Role(ERole.ROLE_DEVELOPER)));
-        Mockito.when(roleRepository.findByName(ERole.ROLE_ADMIN)).thenReturn(
-            java.util.Optional.of(new Role(ERole.ROLE_ADMIN)));
-
-        Mockito.when(localeService.getLocale(null)).thenReturn(new Locale("dk"));
-        Mockito.doNothing().when(mailService)
-            .sendVerificationEmail(user.getEmail(), user.getToken(), new Locale("dk"));
-
-        mvc.perform(post("/auth/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtilsService.asJsonString(signupRequest)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("userId", is(user.getUserId().toString())))
-            .andExpect(jsonPath("email", is(user.getEmail())))
-            .andExpect(jsonPath("$.roles", hasSize(3)))
-            .andExpect(jsonPath("tokenType", is("Bearer")))
-            .andExpect(jsonPath("accessToken", is(notNullValue())));
-    }
 }


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #72
🏁 Jira Issue: none

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [ ] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

Remove the logic for registering a user with multiple roles
Remove the roles field from the signup request DTO

### How should this be manually tested?

Make a postman request to the API that contains a roles field. Example:
Endpoint: POST `localhost:5000/auth/signup`
Body:
```json
{
    "email": "test@gmail.com",
    "password": "abcDEF123",
    "roles": ["ROLE_USER", "invalidRole", "ROLE_ADMIN", "ROLE_DEVELOPER"]
}
```
Expected result: New user with role: `ROLE_USER`
> The body can contain more fields than DTO allows, they just get ignored. This is because we don't have strict DTOs enabled (we may enable them in the future)

### Screenshots or example usage

<!--- Insert images here -->
