### PR TITLE
fix: 🐛Fix banner not showing on firefox

### DIFF
--- a/apps/webstore/src/app/pages/product/product.component.scss
+++ b/apps/webstore/src/app/pages/product/product.component.scss
@@ -274,10 +274,3 @@
   text-align: center;
   padding: 20px;
 }
-
-@-moz-document url-prefix() {
-  .option-banner,
-  .option-tree-design {
-    display: none !important;
-  }
-}

--- a/libs/assets/src/lib/family-tree/banner/banner1.svg
+++ b/libs/assets/src/lib/family-tree/banner/banner1.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg width="1372.7" height="471.4"  version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1270.1 287.6" style="enable-background:new 0 0 1270.1 287.6;" xml:space="preserve">
 <style type="text/css">
 	.st0{display:none;fill:#934141;}


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #221

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [x] Tested on Safari
- [x] Tested on Chrome
- [x] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->

Add width and height to banner svg
Re-enable the button for banner on firefox

### How should this be manually tested?

<!--- Write the steps here -->

Open the products page in firefox

### Screenshots or example usage

<!--- Insert images here -->
