### PR TITLE
fix: 🐛 Fix banner not having the right aspect ratio

### DIFF
--- a/libs/assets/src/lib/family-tree/banner/banner1.svg
+++ b/libs/assets/src/lib/family-tree/banner/banner1.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg width="1372.7" height="471.4"  version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg width="1270.1" height="287.6" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1270.1 287.6" style="enable-background:new 0 0 1270.1 287.6;" xml:space="preserve">
 <style type="text/css">
 	.st0{display:none;fill:#934141;}


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: null
### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates
 
- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [x] Tested on Safari
- [x] Tested on Chrome
- [x] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->

Adjust the banner svg dimensions to match the previous aspect ratio and not distort the text

### How should this be manually tested?

<!--- Write the steps here -->

Open the products page and put text into the banner. Should be aligned

### Screenshots or example usage

<!--- Insert images here -->
![image](https://user-images.githubusercontent.com/22862227/142230733-133dc8c2-b121-4f65-8a88-51f6d8850413.png)
