### PR TITLE
refactor: 💡adjust orderId creation logic to include env

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
@@ -51,10 +51,8 @@ public class QuickpayService
                 order.getDiscount(), order.getContactInfo(),
                 order.getBillingInfo() != null ? order.getBillingInfo() : order.getContactInfo(),
                 order.getShippingMethod(), order.getTransactionItems());
-        // TODO - fully setup environment in API (currently is just a custom property.)
-        // The environment should affect urls included in the emails etc
         payment.order_id =
-            createOrderId(order.getContactInfo().getEmail(), Environment.DEVELOPMENT);
+            createOrderId(order.getContactInfo().getEmail(), customProperties.getEnvironment());
 
         // perform POST https://api.quickpay.net/payments to create a payment object in Quickpay
         String quickpayApiUrl = "https://api.quickpay.net";


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #233

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [ ] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->
Make the orderId for the quickpay payment object represent the environment the order was made in.
Before it was hardcoded to development, thanks to this issue it is dynamic

### How should this be manually tested?

<!--- Write the steps here -->

Make an order while running the API in testing. The created quickpay payment orderId will begin with D (development).
Make an order while running the API in production. The created quickpay payment orderId will begin with P (production)

### Screenshots or example usage

<!--- Insert images here -->
`OrderId for payment created while running the API in production`
![image](https://user-images.githubusercontent.com/22862227/142479287-f9fb86b1-b9cb-4ca7-84a5-293f60042a8c.png)
