### PR TITLE
Feat/#172 add createdat updatedat to all models

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/authentication/models/Role.java
+++ b/apps/api/src/main/java/dk/treecreate/api/authentication/models/Role.java
@@ -1,9 +1,13 @@
 package dk.treecreate.api.authentication.models;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
+import java.util.Date;
 import java.util.UUID;
 
 @Entity
@@ -29,6 +33,16 @@ public class Role
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
     private ERole name;
+
+    @ApiModelProperty(name = "Date the entity was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public Role()
     {
@@ -58,6 +72,26 @@ public class Role
     public void setName(ERole name)
     {
         this.name = name;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public String toString()

--- a/apps/api/src/main/java/dk/treecreate/api/contactinfo/ContactInfo.java
+++ b/apps/api/src/main/java/dk/treecreate/api/contactinfo/ContactInfo.java
@@ -1,13 +1,16 @@
 package dk.treecreate.api.contactinfo;
 
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -77,6 +80,16 @@ public class ContactInfo
     @ApiModelProperty(example = "Denmark")
     @Column(name = "country", length = 50)
     private String country;
+
+    @ApiModelProperty(name = "Date the entity was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public UUID getContactInfoId()
     {
@@ -166,6 +179,26 @@ public class ContactInfo
     public void setCountry(String country)
     {
         this.country = country;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/designs/Design.java
+++ b/apps/api/src/main/java/dk/treecreate/api/designs/Design.java
@@ -3,10 +3,13 @@ package dk.treecreate.api.designs;
 import dk.treecreate.api.user.User;
 import dk.treecreate.api.utils.HashMapConverter;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -57,6 +60,16 @@ public class Design
     @Column(name = "mutable", columnDefinition = "boolean default true", nullable = false)
     @ApiModelProperty(notes = "Can the design be changed", example = "true", required = true)
     private boolean mutable = true;
+
+    @ApiModelProperty(name = "Date the entity was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public Design()
     {
@@ -111,6 +124,26 @@ public class Design
     public void setMutable(boolean mutable)
     {
         this.mutable = mutable;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/designs/dto/UpdateDesignRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/designs/dto/UpdateDesignRequest.java
@@ -3,7 +3,6 @@ package dk.treecreate.api.designs.dto;
 import dk.treecreate.api.designs.DesignType;
 import io.swagger.annotations.ApiModelProperty;
 
-import javax.persistence.Column;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;

--- a/apps/api/src/main/java/dk/treecreate/api/discount/Discount.java
+++ b/apps/api/src/main/java/dk/treecreate/api/discount/Discount.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;
@@ -71,10 +72,15 @@ public class Discount
     @Column(name = "expires_at", nullable = true)
     private Date expiresAt;
 
-    @ApiModelProperty(name = "Date the discount entry was created at",
+    @ApiModelProperty(name = "Date the entity was created at",
         example = "2021-08-31T19:40:10.000+00:00")
     @CreationTimestamp
     private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public UUID getDiscountId()
     {
@@ -154,6 +160,16 @@ public class Discount
     public void setCreatedAt(Date createdAt)
     {
         this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/discount/DiscountController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/discount/DiscountController.java
@@ -65,7 +65,8 @@ public class DiscountController
     {
         Discount discount = new Discount();
         discount.setType(createDiscountRequest.getType());
-        if (discount.getType().equals(DiscountType.PERCENT) && createDiscountRequest.getAmount() > 100)
+        if (discount.getType().equals(DiscountType.PERCENT) &&
+            createDiscountRequest.getAmount() > 100)
         {
             discount.setAmount(100);
         } else

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/Newsletter.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/Newsletter.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
@@ -46,10 +47,15 @@ public class Newsletter
         required = true)
     private String email;
 
-    @ApiModelProperty(name = "Date the newsletter entry was created at",
+    @ApiModelProperty(name = "Date the entity was created at",
         example = "2021-08-31T19:40:10.000+00:00")
     @CreationTimestamp
     private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public Newsletter()
     {
@@ -81,9 +87,19 @@ public class Newsletter
         return createdAt;
     }
 
-    public void setCreatedDate(Date createdAt)
+    public void setCreatedAt(Date createdAt)
     {
         this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/order/Order.java
+++ b/apps/api/src/main/java/dk/treecreate/api/order/Order.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;
@@ -98,10 +99,15 @@ public class Order
     @ApiModelProperty(notes = "Transaction items of the given order")
     private List<TransactionItem> transactionItems;
 
-    @ApiModelProperty(name = "Date the discount entry was created at",
+    @ApiModelProperty(name = "Date the entity was created at",
         example = "2021-08-31T19:40:10.000+00:00")
     @CreationTimestamp
     private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public UUID getOrderId()
     {
@@ -241,6 +247,16 @@ public class Order
     public void setCreatedAt(Date createdAt)
     {
         this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/order/OrderRepository.java
+++ b/apps/api/src/main/java/dk/treecreate/api/order/OrderRepository.java
@@ -1,6 +1,5 @@
 package dk.treecreate.api.order;
 
-import dk.treecreate.api.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/apps/api/src/main/java/dk/treecreate/api/order/dto/CreateOrderRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/order/dto/CreateOrderRequest.java
@@ -6,7 +6,6 @@ import dk.treecreate.api.utils.model.quickpay.PaymentState;
 import dk.treecreate.api.utils.model.quickpay.ShippingMethod;
 import io.swagger.annotations.ApiModelProperty;
 
-import javax.persistence.Column;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;

--- a/apps/api/src/main/java/dk/treecreate/api/transactionitem/TransactionItem.java
+++ b/apps/api/src/main/java/dk/treecreate/api/transactionitem/TransactionItem.java
@@ -4,10 +4,13 @@ import dk.treecreate.api.designs.Design;
 import dk.treecreate.api.designs.DesignDimension;
 import dk.treecreate.api.order.Order;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
+import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -55,6 +58,16 @@ public class TransactionItem
 
     @ManyToOne(fetch = FetchType.EAGER, optional = true)
     private Order order;
+
+    @ApiModelProperty(name = "Date the entity was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public UUID getTransactionItemId()
     {
@@ -110,6 +123,26 @@ public class TransactionItem
     public void setOrderId(UUID orderId)
     {
         this.orderId = orderId;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public boolean equals(Object o)

--- a/apps/api/src/main/java/dk/treecreate/api/transactionitem/dto/CreateTransactionItemRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/transactionitem/dto/CreateTransactionItemRequest.java
@@ -9,15 +9,18 @@ import java.util.UUID;
 public class CreateTransactionItemRequest
 {
     @NotNull
-    @ApiModelProperty(notes = "The quantity of how many items are included", example = "1", required = true)
+    @ApiModelProperty(notes = "The quantity of how many items are included", example = "1",
+        required = true)
     private int quantity;
 
     @NotNull
-    @ApiModelProperty(notes = "The dimension of the referenced design", example = "SMALL", required = true)
+    @ApiModelProperty(notes = "The dimension of the referenced design", example = "SMALL",
+        required = true)
     private DesignDimension dimension;
 
     @NotNull
-    @ApiModelProperty(notes = "The id of the referenced design", example = "c0a80121-7ac0-190b-817a-c08ab0a12345", required = true)
+    @ApiModelProperty(notes = "The id of the referenced design",
+        example = "c0a80121-7ac0-190b-817a-c08ab0a12345", required = true)
     private UUID designId;
 
     public int getQuantity()

--- a/apps/api/src/main/java/dk/treecreate/api/transactionitem/dto/UpdateTransactionItemRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/transactionitem/dto/UpdateTransactionItemRequest.java
@@ -9,11 +9,13 @@ import javax.validation.constraints.NotNull;
 public class UpdateTransactionItemRequest
 {
     @NotNull
-    @ApiModelProperty(notes = "The quantity of how many items are included", example = "1", required = true)
+    @ApiModelProperty(notes = "The quantity of how many items are included", example = "1",
+        required = true)
     private int quantity;
 
     @NotNull
-    @ApiModelProperty(notes = "The dimension of the referenced design", example = "SMALL", required = true)
+    @ApiModelProperty(notes = "The dimension of the referenced design", example = "SMALL",
+        required = true)
     private DesignDimension dimension;
 
     public int getQuantity()

--- a/apps/api/src/main/java/dk/treecreate/api/user/User.java
+++ b/apps/api/src/main/java/dk/treecreate/api/user/User.java
@@ -3,17 +3,16 @@ package dk.treecreate.api.user;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import dk.treecreate.api.authentication.models.Role;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Entity
 @Table(name = "users",
@@ -116,6 +115,16 @@ public class User
     @ApiModelProperty(example = "Denmark")
     @Column(name = "country", length = 50)
     private String country;
+
+    @ApiModelProperty(name = "Date the entity was created at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @CreationTimestamp
+    private Date createdAt;
+
+    @ApiModelProperty(name = "Date the entity was updated at",
+        example = "2021-08-31T19:40:10.000+00:00")
+    @UpdateTimestamp
+    private Date updatedAt;
 
     public User()
     {
@@ -266,6 +275,26 @@ public class User
     public void setCountry(String country)
     {
         this.country = country;
+    }
+
+    public Date getCreatedAt()
+    {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt)
+    {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt()
+    {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt)
+    {
+        this.updatedAt = updatedAt;
     }
 
     @Override public String toString()

--- a/apps/api/src/main/java/dk/treecreate/api/user/dto/UpdatePasswordRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/user/dto/UpdatePasswordRequest.java
@@ -28,13 +28,13 @@ public class UpdatePasswordRequest
         this.token = token;
     }
 
-    public void setPassword(String password)
-    {
-        this.password = password;
-    }
-
     public String getPassword()
     {
         return password;
+    }
+
+    public void setPassword(String password)
+    {
+        this.password = password;
     }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/QuickpayService.java
@@ -38,6 +38,15 @@ public class QuickpayService
     @Autowired
     LinkService linkService;
 
+    public static String encode(String key, String data) throws Exception
+    {
+        Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
+        SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
+        sha256_HMAC.init(secret_key);
+
+        return DatatypeConverter.printHexBinary(sha256_HMAC.doFinal(data.getBytes("UTF-8")));
+    }
+
     /**
      * send a POST /payments request to Quickpay, creating a new payment
      *
@@ -269,14 +278,5 @@ public class QuickpayService
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                 "Failed to calculate the checksum for the request body");
         }
-    }
-
-    public static String encode(String key, String data) throws Exception
-    {
-        Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
-        SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
-        sha256_HMAC.init(secret_key);
-
-        return DatatypeConverter.printHexBinary(sha256_HMAC.doFinal(data.getBytes("UTF-8")));
     }
 }

--- a/apps/api/src/main/java/dk/treecreate/api/utils/model/quickpay/dto/CreatePaymentLinkRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/model/quickpay/dto/CreatePaymentLinkRequest.java
@@ -5,7 +5,8 @@ package dk.treecreate.api.utils.model.quickpay.dto;
  */
 public class CreatePaymentLinkRequest
 {
-    public int amount; // no floating points, multiply the values by 100 to get two-points of precision!
+    public int amount;
+        // no floating points, multiply the values by 100 to get two-points of precision!
     public String language;
     public String continue_url;
     public String cancel_url;

--- a/libs/interfaces/src/lib/design/design.interface.ts
+++ b/libs/interfaces/src/lib/design/design.interface.ts
@@ -1,9 +1,8 @@
-import { IUser } from '../user';
-import { DesignTypeEnum } from './design-type.enum';
 import { ComponentRef } from '@angular/core';
 import { BoxDesignEnum, TreeDesignEnum } from '@assets';
+import { DesignTypeEnum, IBase, IUser } from '..';
 
-export interface IDesign {
+export interface IDesign extends IBase {
   designId: string;
   designProperties: IFamilyTree;
   designType: DesignTypeEnum;

--- a/libs/interfaces/src/lib/index.ts
+++ b/libs/interfaces/src/lib/index.ts
@@ -5,3 +5,4 @@ export * from './order';
 export * from './pricing';
 export * from './transaction-item';
 export * from './user';
+export * from './util';

--- a/libs/interfaces/src/lib/order/order.interface.ts
+++ b/libs/interfaces/src/lib/order/order.interface.ts
@@ -1,12 +1,13 @@
 import {
   CurrencyEnum,
+  IBase,
   ITransactionItem,
   PaymentStateEnum,
   ShippingMethodEnum,
-} from '@interfaces';
+} from '..';
 import { IDiscount } from '../pricing';
 
-export interface IOrder {
+export interface IOrder extends IBase {
   orderId: string;
   subtotal: number;
   total: number;

--- a/libs/interfaces/src/lib/pricing/discount.interface.ts
+++ b/libs/interfaces/src/lib/pricing/discount.interface.ts
@@ -1,6 +1,6 @@
-import { DiscountType } from '@interfaces';
+import { DiscountType, IBase } from '..';
 
-export interface IDiscount {
+export interface IDiscount extends IBase {
   discountId?: string;
   discountCode: string;
   type: DiscountType;

--- a/libs/interfaces/src/lib/transaction-item/transaction-item.interface.ts
+++ b/libs/interfaces/src/lib/transaction-item/transaction-item.interface.ts
@@ -1,6 +1,6 @@
-import { DesignDimensionEnum, IDesign, IFamilyTree } from '../design';
+import { DesignDimensionEnum, IBase, IDesign, IFamilyTree } from '..';
 
-export interface ITransactionItem {
+export interface ITransactionItem extends IBase {
   transactionItemId: string;
   orderId: string;
   dimension: DesignDimensionEnum;

--- a/libs/interfaces/src/lib/user/user.interface.ts
+++ b/libs/interfaces/src/lib/user/user.interface.ts
@@ -1,3 +1,5 @@
+import { IBase } from '..';
+
 export interface IAuthUser {
   userId: string;
   email: string;
@@ -5,7 +7,7 @@ export interface IAuthUser {
   accessToken: string;
   tokenType: string;
 }
-export interface IUser {
+export interface IUser extends IBase {
   userId: string;
   email: string;
   roles: string[];

--- a/libs/interfaces/src/lib/util/base.interface.ts
+++ b/libs/interfaces/src/lib/util/base.interface.ts
@@ -1,0 +1,4 @@
+export interface IBase {
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/libs/interfaces/src/lib/util/index.ts
+++ b/libs/interfaces/src/lib/util/index.ts
@@ -1,0 +1,1 @@
+export * from './base.interface';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10915,6 +10915,9 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "optional": true
+    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "dev": true,
@@ -33218,6 +33221,9 @@
     },
     "fs.realpath": {
       "version": "1.0.0"
+    },
+    "fsevents": {
+      "optional": true
     },
     "fstream": {
       "version": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10915,9 +10915,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "optional": true
-    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "dev": true,
@@ -33221,9 +33218,6 @@
     },
     "fs.realpath": {
       "version": "1.0.0"
-    },
-    "fsevents": {
-      "optional": true
     },
     "fstream": {
       "version": "1.0.12",


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #172 

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [x] 🛒 webstore
- [x] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->
Add two fields, `createdAt` and `updatedAt` to every database model. The fields are automatically filled out when an entity is created or updated. The fields are a timestamp (so date and time)
Updated the frontend interfaces to reflect the changes (only Entity interfaces, not API responses)

The fields are optional and never required in a request

### How should this be manually tested?

<!--- Write the steps here -->
Use the website anywhere that API requests are made (creating orders, updating user info, signing up).
The functionality should work, and the database fields should be updated accordingly

### Screenshots or example usage

<!--- Insert images here -->
