### PR TITLE
Fix/#245 Fix discounts in no-auth page flow

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/config/WebSecurityConfig.java
+++ b/apps/api/src/main/java/dk/treecreate/api/config/WebSecurityConfig.java
@@ -70,6 +70,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter
             .antMatchers("/users/resetPassword/{email}").permitAll()
             .antMatchers("/users/updatePassword").permitAll()
             .antMatchers("/paymentCallback").permitAll()
+            .antMatchers("/discounts/{discountCode}").permitAll()
             .antMatchers("/newsletter").authenticated()
             .antMatchers("/newsletter/me").authenticated()
             .antMatchers("/newsletter/**").permitAll()

--- a/apps/api/src/main/java/dk/treecreate/api/discount/DiscountController.java
+++ b/apps/api/src/main/java/dk/treecreate/api/discount/DiscountController.java
@@ -45,7 +45,6 @@ public class DiscountController
         @ApiResponse(code = 200, message = "Discount information",
             response = Discount.class),
         @ApiResponse(code = 404, message = "Discount not found")})
-    @PreAuthorize("hasRole('USER') or hasRole('DEVELOPER') or hasRole('ADMIN')")
     public Discount getByDiscountCode(
         @ApiParam(name = "discountCode", example = "ExampleDiscount2021")
         @PathVariable String discountCode)


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #245

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->
- Make the endpoint public so that the discount can be applied when the user isn't logged in

### How should this be manually tested?

<!--- Write the steps here -->
 Go through the order creation process without signing in. Apply a discount, should apply without errors

### Screenshots or example usage

<!--- Insert images here -->
