### PR TITLE
fix/244 fix locale change breaking navigation

### DIFF
--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -37,9 +37,9 @@ export class AppComponent {
       const locale = this.localStorageService.getItem<LocaleType>(LocalStorageVars.locale).getValue();
       // if the website is deployed the url has locale in it and has to be adjusted to match local storage
       if (window.location.href.includes('/en-US/') && locale === LocaleType.dk) {
-        window.location.href = window.location.href.replace('en-US', 'dk');
+        window.location.href = window.location.href.replace('/en-US/', '/dk/');
       } else if (window.location.href.includes('/dk/') && locale === LocaleType.en) {
-        window.location.href = window.location.href.replace('dk', 'en-US');
+        window.location.href = window.location.href.replace('/dk/', '/en-US/');
       }
     });
   }


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #244

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->
Change how the URL locale path param gets replaced. Before it would replace the domain (`dk`) instead of the URL path responsible for the locale
Videos below

### How should this be manually tested?

<!--- Write the steps here -->

Go to [testing.treecreate.dk/dk/home](https://testing.treecreate.dk/dk/home). Change locale to english, load the page again (by selecting the URL and pressing enter). Shouldn't break and the URL should adjust automatically to `https://testing.treecreate.dk/en-US/home`
  > The bug is present in production at the moment. With he bug, the URL becomes `https://testing.treecreate.en-US/dk/home`

### Screenshots or example usage
`Example of the bug in production`
https://user-images.githubusercontent.com/22862227/142805980-0aace053-06f0-410f-9b80-270f2f824d41.mov


