### PR TITLE
Fix/#248 fix design miniature styling

### DIFF
--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -235,7 +235,6 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
     this.context = this.designCanvas.nativeElement.getContext('2d');
     console.log('Context', this.context);
 
-    for (let i = 0; i < this.myBoxes.length; i++) {}
     // run the render loop
     clearInterval(this.timeInterval);
 
@@ -256,8 +255,8 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
   }
 
   updateBoxRefText() {
-    for (let i = 0; i < this.myBoxes.length; i++) {
-      this.myBoxes[i].text = this.myBoxes[i].inputRef.instance.text;
+    for (const box of this.myBoxes) {
+      box.text = box.inputRef.instance.text;
     }
   }
 
@@ -674,8 +673,7 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
 
       let boxesGotMousedOver = false;
 
-      for (let i = 0; i < this.myBoxes.length; i++) {
-        const box = this.myBoxes[i];
+      for (const box of this.myBoxes) {
         if (!this.mouseOutsideBoundaries(this.boxDimensions.width, this.boxDimensions.height)) {
           // check if any of the boxes got moused over
           if (
@@ -690,8 +688,8 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
           if (box.dragging) {
             {
               // move the box with the cursor
-              this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
-              this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
+              box.x = this.mouseCords.x - this.mouseClickOffset.x;
+              box.y = this.mouseCords.y - this.mouseClickOffset.y;
               // skip checking the other boxes
               return;
             }
@@ -712,21 +710,20 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
       event = event || window.event;
       this.mouseCords = this.getMousePosition(this.designCanvas.nativeElement, event);
 
-      for (let i = 0; i < this.myBoxes.length; i++) {
-        const box = this.myBoxes[i];
+      for (const box of this.myBoxes) {
         if (box.dragging) {
           if (this.mouseOutsideBoundaries(this.boxDimensions.width, this.boxDimensions.height)) {
             // send back to its last saved position
-            this.myBoxes[i].x = box.previousX;
-            this.myBoxes[i].y = box.previousY;
-            this.myBoxes[i].dragging = false;
+            box.x = box.previousX;
+            box.y = box.previousY;
+            box.dragging = false;
           } else {
             // save the box in its new position
-            this.myBoxes[i].x = this.mouseCords.x - this.mouseClickOffset.x;
-            this.myBoxes[i].y = this.mouseCords.y - this.mouseClickOffset.y;
-            this.myBoxes[i].previousX = this.mouseCords.x - this.mouseClickOffset.x;
-            this.myBoxes[i].previousY = this.mouseCords.y - this.mouseClickOffset.y;
-            this.myBoxes[i].dragging = false;
+            box.x = this.mouseCords.x - this.mouseClickOffset.x;
+            box.y = this.mouseCords.y - this.mouseClickOffset.y;
+            box.previousX = this.mouseCords.x - this.mouseClickOffset.x;
+            box.previousY = this.mouseCords.y - this.mouseClickOffset.y;
+            box.dragging = false;
           }
           // skip checking the other boxes
           return;
@@ -738,7 +735,6 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
   }
 
   // Util methods
-  // TODO: Extract them into a library
 
   getImageElementFromBoxDesign(treeDesign: TreeDesignEnum, boxDesign: BoxDesignEnum): HTMLImageElement {
     switch (treeDesign) {

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-design/family-tree-design.component.ts
@@ -25,8 +25,9 @@ import {
   TreeDesignEnum,
 } from '@assets';
 import { FamilyTreeFontEnum, IDesign, IDraggableBox, IFamilyTree, IFamilyTreeBanner } from '@interfaces';
-import { LocalStorageVars } from '@models';
 import { LocalStorageService } from '@local-storage';
+import { LocalStorageVars } from '@models';
+import { FamilyTreeDesignService } from '../../../../services/design/family-tree-design.service';
 import { DraggableBoxComponent } from '../draggable-box/draggable-box.component';
 
 @Component({
@@ -147,7 +148,8 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
   constructor(
     private resolver: ComponentFactoryResolver,
     private cdr: ChangeDetectorRef,
-    private localStorageService: LocalStorageService
+    private localStorageService: LocalStorageService,
+    private familyTreeDesignService: FamilyTreeDesignService
   ) {}
 
   ngOnInit(): void {
@@ -391,58 +393,14 @@ export class FamilyTreeDesignComponent implements AfterViewInit, OnInit, OnChang
               this.closeButtonDimensions.height
             );
           }
-
-          // Draw the text within the box
-          // fancy math to make the value scale well with box size. Source of values: https://www.dcode.fr/function-equation-finder
-          // times 5 to account for having different scale
-          // NOTE - can cause performance issues since it occurs on every frame
-          const boxTextFontSize = (0.0545 * this.boxSize + 0.05) * (this.isLargeFont ? 7 : 5); // in rem
-          // TODO: add multi-line support
-          this.context.font = `${boxTextFontSize}rem ${this.font}`;
-          this.context.textAlign = 'center';
-          this.context.textBaseline = 'middle';
-          let line = '';
-          let currentLine = 1;
-          const words = this.myBoxes[i].text.substring(0, this.maxCharsPerLine * this.maxLines).split(' ');
-          const multiLineText = this.myBoxes[i].text.length > this.maxCharsPerLine;
-          const x = this.myBoxes[i].x + this.boxDimensions.width / 2;
-          let y = this.myBoxes[i].y + this.boxDimensions.height / 2;
-          const lineHeight = (this.boxDimensions.height / 5) * 1;
-          if (multiLineText) {
-            y = this.myBoxes[i].y + (this.boxDimensions.height / 5) * 2;
-          }
-          const formattedWords = [];
-          words.forEach((word) => {
-            do {
-              if (word.length === 0) {
-                break;
-              }
-              if (word.length >= this.maxCharsPerLine) {
-                formattedWords.push(word.substring(0, this.maxCharsPerLine));
-                word = word.substring(this.maxCharsPerLine, word.length);
-              } else {
-                formattedWords.push(word);
-                word = '';
-              }
-            } while (word !== '');
-          });
-          // print out the text
-          for (let j = 0; j < formattedWords.length; j++) {
-            const testLine = line + formattedWords[j] + ' ';
-
-            if (testLine.length - 1 > this.maxCharsPerLine) {
-              currentLine++;
-              if (currentLine > this.maxLines) {
-                break;
-              }
-              this.context.fillText(line, x, y);
-              line = formattedWords[j] + ' ';
-              y += lineHeight;
-            } else {
-              line = testLine;
-            }
-          }
-          this.context.fillText(line, x, y);
+          this.familyTreeDesignService.drawTextInDraggableBox(
+            this.context,
+            this.boxSize,
+            this.isLargeFont,
+            this.font,
+            this.myBoxes[i],
+            this.boxDimensions
+          );
         }
       }
       this.frameChanged = false;

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
@@ -282,8 +282,7 @@ export class FamilyTreeMiniatureComponent implements AfterViewInit, OnInit, OnCh
       }
 
       // render the boxes
-      for (let i = 0; i < this.myBoxes.length; i++) {
-        const box = this.myBoxes[i];
+      for (const box of this.myBoxes) {
         this.context.drawImage(
           this.getImageElementFromBoxDesign(this.design.backgroundTreeDesign, box.boxDesign),
           box.x,
@@ -297,7 +296,7 @@ export class FamilyTreeMiniatureComponent implements AfterViewInit, OnInit, OnCh
           this.boxSize,
           this.design.largeFont,
           this.design.font,
-          this.myBoxes[i],
+          box,
           this.boxDimensions
         );
       }

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
@@ -20,6 +20,7 @@ import {
   TreeDesignEnum,
 } from '@assets';
 import { IDesign, IDraggableBox, IFamilyTree } from '@interfaces';
+import { FamilyTreeDesignService } from '../../../../services/design/family-tree-design.service';
 
 @Component({
   selector: 'webstore-family-tree-miniature',
@@ -99,7 +100,7 @@ export class FamilyTreeMiniatureComponent implements AfterViewInit, OnInit, OnCh
   // TODO: show only for one box instead of showing it for all if any of the boxes got moused over
   showDeleteBoxButtons = false;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, private familyTreeDesignService: FamilyTreeDesignService) {}
 
   ngOnInit(): void {
     // Load and validate tree design SVGs
@@ -291,57 +292,14 @@ export class FamilyTreeMiniatureComponent implements AfterViewInit, OnInit, OnCh
           this.boxDimensions.height
         );
 
-        // Draw the text within the box
-        // fancy math to make the value scale well with box size. Source of values: https://www.dcode.fr/function-equation-finder
-        // times 5 to account for having different scale
-        // NOTE - can cause performance issues since it occurs on every frame
-        const boxTextFontSize = (0.0545 * this.boxSize + 0.05) * (this.design.largeFont ? 7 : 5); // in rem
-        // TODO: add multi-line support
-        this.context.font = `${boxTextFontSize}rem ${this.design.font}`;
-        this.context.textAlign = 'center';
-        this.context.textBaseline = 'middle';
-        let line = '';
-        let currentLine = 1;
-        const words = this.myBoxes[i].text.substring(0, this.maxCharsPerLine * this.maxLines).split(' ');
-        const multiLineText = this.myBoxes[i].text.length > this.maxCharsPerLine;
-        const x = this.myBoxes[i].x + this.boxDimensions.width / 2;
-        let y = this.myBoxes[i].y + this.boxDimensions.height / 2;
-        const lineHeight = (this.boxDimensions.height / 5) * 1;
-        if (multiLineText) {
-          y = this.myBoxes[i].y + (this.boxDimensions.height / 5) * 2;
-        }
-        const formattedWords = [];
-        words.forEach((word) => {
-          do {
-            if (word.length === 0) {
-              break;
-            }
-            if (word.length >= this.maxCharsPerLine) {
-              formattedWords.push(word.substring(0, this.maxCharsPerLine));
-              word = word.substring(this.maxCharsPerLine, word.length);
-            } else {
-              formattedWords.push(word);
-              word = '';
-            }
-          } while (word !== '');
-        });
-        // print out the text
-        for (let j = 0; j < formattedWords.length; j++) {
-          const testLine = line + formattedWords[j] + ' ';
-
-          if (testLine.length - 1 > this.maxCharsPerLine) {
-            currentLine++;
-            if (currentLine > this.maxLines) {
-              break;
-            }
-            this.context.fillText(line, x, y);
-            line = formattedWords[j] + ' ';
-            y += lineHeight;
-          } else {
-            line = testLine;
-          }
-        }
-        this.context.fillText(line, x, y);
+        this.familyTreeDesignService.drawTextInDraggableBox(
+          this.context,
+          this.boxSize,
+          this.design.largeFont,
+          this.design.font,
+          this.myBoxes[i],
+          this.boxDimensions
+        );
       }
     } catch (error) {
       console.error('An error has occurred while drawing the tree', error);

--- a/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
+++ b/apps/webstore/src/app/shared/components/products/family-tree/family-tree-miniature/family-tree-miniature.component.ts
@@ -6,6 +6,7 @@ import {
   Input,
   OnChanges,
   OnInit,
+  SimpleChanges,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
@@ -181,12 +182,28 @@ export class FamilyTreeMiniatureComponent implements AfterViewInit, OnInit, OnCh
     this.draw();
   }
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
+    // handle input value updates
+
+    if (changes.boxSize !== undefined) {
+      this.boxDimensions = {
+        height: (this.canvasResolution.height / 10) * (this.boxSize * this.boxSizeScalingMultiplier),
+        width: (this.canvasResolution.width / 5) * (this.boxSize * this.boxSizeScalingMultiplier),
+      };
+
+      this.closeButtonDimensions = {
+        height: (this.canvasResolution.height / 20) * (this.boxSize * this.boxSizeScalingMultiplier),
+        width: (this.canvasResolution.width / 20) * (this.boxSize * this.boxSizeScalingMultiplier),
+      };
+    }
+
     if (this.design !== undefined && this.context !== undefined) {
       this.loadDesign();
 
       this.maxCharsPerLine = this.design.largeFont ? this.largeFontMaxChars : this.smallFontMaxChars;
     }
+
+    this.cdr.detectChanges();
   }
 
   // create a new box

--- a/apps/webstore/src/app/shared/services/design/family-tree-design.service.ts
+++ b/apps/webstore/src/app/shared/services/design/family-tree-design.service.ts
@@ -63,8 +63,8 @@ export class FamilyTreeDesignService {
       } while (word !== '');
     });
     // print out the text
-    for (let j = 0; j < formattedWords.length; j++) {
-      const testLine = line + formattedWords[j] + ' ';
+    for (const word of formattedWords) {
+      const testLine = line + word + ' ';
 
       if (testLine.length - 1 > maxCharsPerLine) {
         currentLine++;
@@ -72,7 +72,7 @@ export class FamilyTreeDesignService {
           break;
         }
         context.fillText(line, x, y);
-        line = formattedWords[j] + ' ';
+        line = word + ' ';
         y += lineHeight;
       } else {
         line = testLine;

--- a/apps/webstore/src/app/shared/services/design/family-tree-design.service.ts
+++ b/apps/webstore/src/app/shared/services/design/family-tree-design.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { FamilyTreeFontEnum, IDraggableBox } from '@interfaces';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FamilyTreeDesignService {
+  // the max chars control how much text can be put into the draggable box
+  // It is propagated to the draggable box input element
+  smallFontMaxChars = 12;
+  largeFontMaxChars = 9;
+  maxLines = 2;
+
+  /**
+   * Draw the text within a draggable box
+   * @param context canvas context
+   * @param boxSize size of the draggable box the text should be written in. Affect font size
+   * @param isLargeFont  whether the font is large or normal. Affects font size
+   * @param font which font to use
+   * @param box draggable box object. Used to get info like text and x/y coordinates
+   * @param boxDimensions the exact sizing of the box
+   */
+  drawTextInDraggableBox(
+    context: CanvasRenderingContext2D,
+    boxSize: number,
+    isLargeFont: boolean,
+    font: FamilyTreeFontEnum,
+    box: IDraggableBox,
+    boxDimensions: { height: number; width: number }
+  ): void {
+    // fancy math to make the value scale well with box size. Source of values: https://www.dcode.fr/function-equation-finder
+    // times 5 to account for having different scale
+    // NOTE - can cause performance issues since it occurs on every frame
+    const boxTextFontSize = (0.0545 * boxSize + 0.05) * (isLargeFont ? 7 : 5); // in rem
+    // TODO: add multi-line support
+    context.font = `${boxTextFontSize}rem ${font}`;
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    let line = '';
+    let currentLine = 1;
+    const maxCharsPerLine = isLargeFont ? this.largeFontMaxChars : this.smallFontMaxChars;
+    const words = box.text.substring(0, maxCharsPerLine * this.maxLines).split(' ');
+    const multiLineText = box.text.length > maxCharsPerLine;
+    const x = box.x + boxDimensions.width / 2;
+    let y = box.y + boxDimensions.height / 2;
+    const lineHeight = (boxDimensions.height / 5) * 1;
+    if (multiLineText) {
+      y = box.y + (boxDimensions.height / 5) * 2;
+    }
+    const formattedWords = [];
+    words.forEach((word) => {
+      do {
+        if (word.length === 0) {
+          break;
+        }
+        if (word.length >= maxCharsPerLine) {
+          formattedWords.push(word.substring(0, maxCharsPerLine));
+          word = word.substring(maxCharsPerLine, word.length);
+        } else {
+          formattedWords.push(word);
+          word = '';
+        }
+      } while (word !== '');
+    });
+    // print out the text
+    for (let j = 0; j < formattedWords.length; j++) {
+      const testLine = line + formattedWords[j] + ' ';
+
+      if (testLine.length - 1 > maxCharsPerLine) {
+        currentLine++;
+        if (currentLine > this.maxLines) {
+          break;
+        }
+        context.fillText(line, x, y);
+        line = formattedWords[j] + ' ';
+        y += lineHeight;
+      } else {
+        line = testLine;
+      }
+    }
+    context.fillText(line, x, y);
+  }
+}


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #248

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [x] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

<!--- Write a short summary here -->
- Fix a non-default box size not being reflected properly in design miniatures/no-edit mode (they are the same)
- Fix the draggable box text styling/behaviour not fully matching between the edit and no-edit views

### How should this be manually tested?

<!--- Write the steps here -->
Create a design, add it to basket. Compare your design and what is shown in the no-edit view (accessible via the basket-> view). The designs should look the same


### Screenshots or example usage

<!--- Insert images here -->
### Bug showcase: design with max box size and large font
`Created design`
![image](https://user-images.githubusercontent.com/22862227/142809892-e4ec3f6d-21fe-4515-ab2c-f099a4a8be66.png)
`View-only version `
![image](https://user-images.githubusercontent.com/22862227/142809920-cf1b5b34-dd9a-4cfd-945c-9b1f975a5c09.png)
