### PR TITLE
perf: add fixed workspace.json

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -29,6 +29,14 @@
             "scripts": []
           },
           "configurations": {
+            "development": {
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "buildOptimizer": false,
+              "sourceMap": true,
+              "optimization": false,
+              "namedChunks": true
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -56,12 +64,14 @@
                 }
               ]
             }
-          }
+          },
+          "defaultConfiguration": "production"
         },
         "serve": {
-          "executor": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "defaultConfiguration": "",
           "options": {
-            "browserTarget": "admin-page:build",
+            "browserTarget": "admin-page:build:development",
             "proxyConfig": "apps/admin-page/proxy.conf.json",
             "port": 4300
           },
@@ -330,6 +340,14 @@
             "scripts": []
           },
           "configurations": {
+            "development": {
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "buildOptimizer": false,
+              "sourceMap": true,
+              "optimization": false,
+              "namedChunks": true
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -370,12 +388,14 @@
               ],
               "localize": ["dk"]
             }
-          }
+          },
+          "defaultConfiguration": "production"
         },
         "serve": {
-          "executor": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "defaultConfiguration": "",
           "options": {
-            "browserTarget": "webstore:build"
+            "browserTarget": "webstore:build:development"
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
### This pull request closes:

✔️ Closes: #265 

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [x] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [x] ⚗️ Refactoring (an update to some already existing code)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [x] Tested on Safari
- [x] Tested on Chrome
- [x] Tested on Mozilla Firefox

### What changes have been done within this issue?

Added "development" build config in workspace.json under the paths:
`admin-page.targets.build.configurations`
`webstore.targets.build.configurations`

added a new `"defaultConfiguration": "production"` flag

Changed both `admin-page:serve` and `webstore:serve` to use the new `"development"` builder.

### How should this be manually tested?

Run nx serve <app-name> and then edit any file.

Reload speed on admin page (on my machine) went from 8 second average to 800ms average

### Screenshots or example usage

Webstore reload speed old: (used dk here since it is not optimized and mimics old behaviour)
![image](https://user-images.githubusercontent.com/57399961/143758064-fb87c953-58d3-4a37-9b91-47c947bb6ef6.png)
![image](https://user-images.githubusercontent.com/57399961/143758246-0f9a4628-e64b-4817-a344-487c5f9baa26.png)




Webstore reload speed new:
![image](https://user-images.githubusercontent.com/57399961/143756411-b92c6393-463e-4e30-87c5-aabd6310ecfb.png)


