### PR TITLE
chore: 🤖 Add popperjs package to match bootstrap dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@nrwl/cli": "13.7.1",
         "@nrwl/nx-cloud": "13.1.2",
         "@nrwl/workspace": "13.7.1",
+        "@popperjs/core": "^2.11.5",
         "bootstrap": "^5.0.0",
         "ngx-clipboard": "^15.1.0",
         "rxjs": "^7.4.0",
@@ -4572,7 +4573,6 @@
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -21870,8 +21870,7 @@
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "peer": true
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@schematics/angular": {
       "version": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@nrwl/cli": "13.7.1",
     "@nrwl/nx-cloud": "13.1.2",
     "@nrwl/workspace": "13.7.1",
+    "@popperjs/core": "^2.11.5",
     "bootstrap": "^5.0.0",
     "ngx-clipboard": "^15.1.0",
     "rxjs": "^7.4.0",


### PR DESCRIPTION
Add an extra package that is a dependency of the new bootstrap version and is required to build the application