### PR TITLE
chore: 🤖 Adjust nginx.conf to serve dk as default locale

### DIFF
--- a/.deploy/webstore/nginx.conf
+++ b/.deploy/webstore/nginx.conf
@@ -6,8 +6,8 @@ http {
   include /etc/nginx/mime.types;
 
   map $http_accept_language $lang {
-  default en-US;
-  ~*^dk dk;
+  default dk;
+  ~*^en-US en-US;
   }
 
   server {


### PR DESCRIPTION
### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

Make the default files served to the user when they navigate to `https://treecreate.dk` be the danish-localized files. This avoids the website having to reload for the danish language, which is the locale that majority of our users use
The old default was English (US)

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage

<!--- Insert images here -->
