### PR TITLE
Feat/#tc 215 rework danish url

### DIFF
--- a/.deploy/.env-files/.env.dev.frontend.example
+++ b/.deploy/.env-files/.env.dev.frontend.example
@@ -1,5 +1,5 @@
 API_URL="http://url_to_dev_api:5050"
-WEBSTORE_URL=https://testing.treecreate.dk/da
-ADMIN_URL=https://admin.testing.treecreate.dk/da
+WEBSTORE_URL=https://testing.treecreate.dk
+ADMIN_URL=https://admin.testing.treecreate.dk
 GTAG="" # Should be left blank for dev runs
 PRERENDER_IO_TOKEN=default_token

--- a/.deploy/.env-files/.env.prod.frontend.example
+++ b/.deploy/.env-files/.env.prod.frontend.example
@@ -1,4 +1,4 @@
 API_URL="http://url_to_production_api:5050"
-WEBSTORE_URL=https://treecreate.dk/da
-ADMIN_URL=https://admin.treecreate.dk/da
+WEBSTORE_URL=https://treecreate.dk
+ADMIN_URL=https://admin.treecreate.dk
 GTAG="your_gtag_here"

--- a/.deploy/webstore/Dockerfile
+++ b/.deploy/webstore/Dockerfile
@@ -23,6 +23,8 @@ COPY ./assets ./assets
 COPY ./libs ./libs
 COPY ./apps/webstore ./apps/webstore
 
+RUN apk --no-cache add --virtual .builds-deps build-base python3
+
 # Run npm install inside container
 # --legacy-peer-deps This line is currently required for the dependencies to install
 # Should be tested once in a while and removed when possible, as package maintainers
@@ -54,4 +56,4 @@ COPY --from=builder /app/dist/apps/webstore /usr/share/nginx/html
 # When the container starts, replace the env.js with values from environment variables via package.json scripts
 
 # Execute nginx on container to launch application after setting angular ENVs
-CMD ["/bin/sh",  "-c",  "envsubst < /usr/share/nginx/html/en-US/assets/env.template.js > /usr/share/nginx/html/en-US/assets/env.js && envsubst < /usr/share/nginx/html/da/assets/env.template.js > /usr/share/nginx/html/da/assets/env.js && envsubst '$PRERENDER_IO_TOKEN' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && rm /etc/nginx/nginx.conf.template && exec nginx -g 'daemon off;'"]
+CMD ["/bin/sh",  "-c",  "envsubst < /usr/share/nginx/html/en-US/assets/env.template.js > /usr/share/nginx/html/en-US/assets/env.js && envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js && envsubst '$PRERENDER_IO_TOKEN' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && rm /etc/nginx/nginx.conf.template && exec nginx -g 'daemon off;'"]

--- a/.deploy/webstore/nginx.conf
+++ b/.deploy/webstore/nginx.conf
@@ -9,7 +9,7 @@ http {
   default_type application/octet-stream;
 
   map $http_accept_language $lang {
-    default da;
+    default '';
     ~*^en-US en-US;
   }
 
@@ -78,23 +78,17 @@ http {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Redirect requests to a localized uri
-    location = / {
-      return 302 /$lang/;
-    }
-
-    # Redirect the assets request to their language-specific uri
-    location ~^/assets {
+    # Default language is Danish with no special url
+    location / {
+      # If the user agent is a crawling bot, return a prerendered version
       if ($prerender = 1) {
         rewrite (.*) /prerenderio last;
       }
-      return 302 /$lang$uri;
+      # Return normal files
+      try_files $uri $uri/ /index.html;
     }
 
-    location ~^/robots.txt {
-      try_files $uri $uri/ /da/robots.txt;
-    }
-
+    # URL that specifies to use Danish localization
     location ~^/en-US {
       # If the user agent is a crawling bot, return a prerendered version
       if ($prerender = 1) {
@@ -102,15 +96,6 @@ http {
       }
       # Return normal files
       try_files $uri $uri/ /en-US/index.html;
-    }
-
-    location ~^/da {
-      # If the user agent is a crawling bot, return a prerendered version
-      if ($prerender = 1) {
-        rewrite (.*) /prerenderio last;
-      }
-      # Return normal files
-      try_files $uri $uri/ /da/index.html;
     }
 
     location /prerenderio {

--- a/.deploy/webstore/nginx.conf
+++ b/.deploy/webstore/nginx.conf
@@ -98,6 +98,24 @@ http {
       try_files $uri $uri/ /en-US/index.html;
     }
 
+    # Handle Legacy URLs
+    location ~^/da {
+      # If the user agent is a crawling bot, return a prerendered version
+      if ($prerender = 1) {
+        rewrite (.*) /prerenderio last;
+      }
+      try_files $uri $uri/ /index.html;
+    }
+    
+    # Handle Legacy URLs
+    location ~^/dk {
+      # If the user agent is a crawling bot, return a prerendered version
+      if ($prerender = 1) {
+        rewrite (.*) /prerenderio last;
+      }
+      try_files $uri $uri/ /index.html;
+    }
+
     location /prerenderio {
       # In case the URI incorrectly triggered the prerended logic return 404
       if ($prerender = 0) {

--- a/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/newsletter/NewsletterService.java
@@ -88,7 +88,7 @@ public class NewsletterService {
       throws MessagingException, UnsupportedEncodingException {
 
     String unsubscribeNewsletterUrl =
-        linkService.generateNewsletterUnsubscribeLink(newsletterId, localeService.getLocale(null));
+        linkService.generateNewsletterUnsubscribeLink(newsletterId, localeService.getLocale(lang));
 
     // generate the discount code
     String discountCode;

--- a/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
+++ b/apps/api/src/main/java/dk/treecreate/api/utils/LinkService.java
@@ -62,7 +62,10 @@ public class LinkService {
   private String getPath(@Nullable Locale locale, String route, boolean isApi) {
     String lang = "";
     if (!isApi) {
-      lang = locale.equals(Locale.ENGLISH) ? "/en-US" : "/da";
+      lang =
+          locale.equals(Locale.ENGLISH)
+              ? "/en-US"
+              : ""; // Danish locale uses the default url, no lang path param
     }
     switch (customProperties.getEnvironment()) {
       case PRODUCTION:

--- a/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
+++ b/apps/api/src/test/java/dk/treecreate/api/utils/LinkServiceTest.java
@@ -48,7 +48,7 @@ public class LinkServiceTest {
             Environment.STAGING,
             new Locale("da"),
             true,
-            "https://testing.treecreate.dk/da/payment/success"),
+            "https://testing.treecreate.dk/payment/success"),
         Arguments.of(
             Environment.STAGING,
             Locale.ENGLISH,
@@ -58,7 +58,7 @@ public class LinkServiceTest {
             Environment.STAGING,
             new Locale("da"),
             false,
-            "https://testing.treecreate.dk/da/payment/cancelled"),
+            "https://testing.treecreate.dk/payment/cancelled"),
         Arguments.of(
             Environment.PRODUCTION,
             Locale.ENGLISH,
@@ -68,7 +68,7 @@ public class LinkServiceTest {
             Environment.PRODUCTION,
             new Locale("da"),
             true,
-            "https://treecreate.dk/da/payment/success"),
+            "https://treecreate.dk/payment/success"),
         Arguments.of(
             Environment.PRODUCTION,
             Locale.ENGLISH,
@@ -78,7 +78,7 @@ public class LinkServiceTest {
             Environment.PRODUCTION,
             new Locale("da"),
             false,
-            "https://treecreate.dk/da/payment/cancelled"));
+            "https://treecreate.dk/payment/cancelled"));
   }
 
   private static Stream<Arguments> generateCallbackUrlArguments() {
@@ -114,12 +114,12 @@ public class LinkServiceTest {
             new UUID(0, 0),
             new Locale("da"),
             Environment.STAGING,
-            "https://testing.treecreate.dk/da/resetPassword/00000000-0000-0000-0000-000000000000"),
+            "https://testing.treecreate.dk/resetPassword/00000000-0000-0000-0000-000000000000"),
         Arguments.of(
             new UUID(0, 0),
             new Locale("da"),
             Environment.PRODUCTION,
-            "https://treecreate.dk/da/resetPassword/00000000-0000-0000-0000-000000000000"));
+            "https://treecreate.dk/resetPassword/00000000-0000-0000-0000-000000000000"));
   }
 
   private static Stream<Arguments> generateNewsletterUnsubscribeLinkArguments() {
@@ -148,12 +148,12 @@ public class LinkServiceTest {
             new UUID(0, 0),
             new Locale("da"),
             Environment.STAGING,
-            "https://testing.treecreate.dk/da/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
+            "https://testing.treecreate.dk/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"),
         Arguments.of(
             new UUID(0, 0),
             new Locale("da"),
             Environment.PRODUCTION,
-            "https://treecreate.dk/da/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"));
+            "https://treecreate.dk/newsletter/unsubscribe/00000000-0000-0000-0000-000000000000"));
   }
 
   @ParameterizedTest

--- a/apps/webstore-e2e/src/integration/components/cookie-prompt.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/cookie-prompt.spec.ts
@@ -1,6 +1,6 @@
 import { CookieStatus, LocalStorageVars } from '@models';
 describe('CookiePromptModal', () => {
-  beforeEach(() => cy.visit('/home'));
+  beforeEach(() => cy.visit('/'));
 
   it('should display a cookie prompt on first visit', () => {
     cy.get('[data-cy=cookie-prompt-modal]').should('exist');
@@ -20,7 +20,7 @@ describe('CookiePromptModal', () => {
           CookieStatus.rejected
         );
         // shouldn't open the prompt when re-visiting the website
-        cy.visit('/home');
+        cy.visit('/');
         cy.get('[data-cy=cookie-prompt-modal]').should('not.exist');
       });
   });
@@ -29,13 +29,13 @@ describe('CookiePromptModal', () => {
     cy.get('[data-cy=cookie-prompt-modal-accept-cookies-btn]')
       .click()
       .then(() => {
-        cy.url().should('contain', '/home');
+        cy.url().should('contain', '/');
         cy.get('[data-cy=cookie-prompt-modal]').should('not.exist');
         expect(localStorage.getItem(LocalStorageVars.cookiesAccepted).replace(new RegExp('"', 'g'), '')).to.equal(
           CookieStatus.accepted
         );
         // shouldn't open the prompt when re-visiting the website
-        cy.visit('/home');
+        cy.visit('/');
         cy.get('[data-cy=cookie-prompt-modal]').should('not.exist');
       });
   });

--- a/apps/webstore-e2e/src/integration/components/footer.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/footer.spec.ts
@@ -5,7 +5,7 @@ describe('FooterComponent', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should contain a footer', () => {

--- a/apps/webstore-e2e/src/integration/components/modals/newsletter-popup-modal.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/modals/newsletter-popup-modal.spec.ts
@@ -1,12 +1,11 @@
 import { LocalStorageVars } from '@models';
 
 describe('Signup to newsletter popup modal', () => {
-  beforeEach(() => {
-    cy.visit('/home');
-  });
+  beforeEach(() => {});
 
   it('should show the popup and save it in localstorage', () => {
     expect(localStorage.getItem(LocalStorageVars.hasSeenNewsletterModal)).to.equal(null);
+    cy.visit('/');
     cy.get('[data-cy=cookie-prompt-modal-accept-cookies-btn]').click();
     cy.get('[data-cy=newsletter-modal-popup]').should('not.exist');
     // eslint-disable-next-line
@@ -23,6 +22,7 @@ describe('Signup to newsletter popup modal', () => {
     cy.intercept('POST', '/newsletter/test@test.com?lang=da', {
       statusCode: 200,
     });
+    cy.visit('/');
     cy.get('[data-cy=cookie-prompt-modal-accept-cookies-btn]').click();
     cy.get('[data-cy=newsletter-modal-popup]').should('not.exist');
     // eslint-disable-next-line

--- a/apps/webstore-e2e/src/integration/components/navbar.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/navbar.spec.ts
@@ -8,7 +8,7 @@ describe('NavbarComponent', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should contain a navbar', () => {
@@ -26,17 +26,17 @@ describe('NavbarComponent', () => {
 
   it('should display profile instead of log in when user is authenticated', () => {
     localStorage.setItem(LocalStorageVars.authUser, JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser)));
-    cy.visit('/home');
+    cy.visit('/');
     cy.get('[data-cy=navbar]').contains('Log in').should('not.exist');
     cy.get('[data-cy=navbar]').contains('Profile').should('exist');
   });
 
   it('should log the out user and clear local storage information', () => {
     localStorage.setItem(LocalStorageVars.authUser, JSON.stringify(authMockService.getMockUser(AuthUserEnum.authUser)));
-    cy.visit('/home');
+    cy.visit('/');
     cy.get('[data-cy=navbar-profile-dropdown]').trigger('mouseenter');
     cy.get('[data-cy=navbar-log-out-btn]').click({ force: true });
-    cy.url().should('contain', '/home');
+    cy.url().should('contain', '/');
     cy.get('[data-cy=navbar]').contains('Log in').should('exist');
     cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');
   });

--- a/apps/webstore-e2e/src/integration/components/privacy-notice.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/privacy-notice.spec.ts
@@ -5,7 +5,7 @@ describe.skip('PrivacyNoticeModal', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should open privacy notice modal when clicked on its link', () => {

--- a/apps/webstore-e2e/src/integration/components/terms-of-sale.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/terms-of-sale.spec.ts
@@ -6,7 +6,7 @@ describe.skip('TermsOfSaleModal', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should open terms of Sale modal when clicked on its link', () => {

--- a/apps/webstore-e2e/src/integration/components/terms-of-use.spec.ts
+++ b/apps/webstore-e2e/src/integration/components/terms-of-use.spec.ts
@@ -5,7 +5,7 @@ describe.skip('TermsOfUseModal', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should open terms of use modal when clicked on its link', () => {

--- a/apps/webstore-e2e/src/integration/pages/auth/login.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/login.spec.ts
@@ -115,7 +115,7 @@ describe('Login Page', () => {
       );
       cy.visit('/login');
 
-      cy.url().should('contain', '/home');
+      cy.url().should('contain', '/');
 
       cy.get('[data-cy=navbar]').contains('Log in').should('exist');
       cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');

--- a/apps/webstore-e2e/src/integration/pages/auth/profile.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/profile.spec.ts
@@ -96,7 +96,7 @@ describe('accountPage', () => {
     cy.get('[data-cy=update-password-btn]').click();
 
     cy.get('[data-cy=change-password-modal]').should('not.exist');
-    cy.url().should('contain', '/home');
+    cy.url().should('contain', '/');
   });
 
   it('should not be able to update password with non matching password', () => {

--- a/apps/webstore-e2e/src/integration/pages/auth/signup.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/signup.spec.ts
@@ -116,7 +116,7 @@ describe('Signup Page', () => {
       );
       cy.visit('/signup');
 
-      cy.url().should('contain', '/home');
+      cy.url().should('contain', '/');
 
       cy.get('[data-cy=navbar]').contains('Log in').should('exist');
       cy.get('[data-cy=navbar]').contains('Profile').should('not.exist');

--- a/apps/webstore-e2e/src/integration/pages/auth/unsubscribe.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/unsubscribe.spec.ts
@@ -60,6 +60,6 @@ describe('Signup Page', () => {
 
     cy.visit('newsletter/unsubscribe/' + subscribedNewsletterUUID);
     cy.get('[data-cy=unsubscribe-home-btn]').click();
-    cy.url().should('contain', '/home');
+    cy.url().should('contain', '/');
   });
 });

--- a/apps/webstore-e2e/src/integration/pages/home.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/home.spec.ts
@@ -5,7 +5,7 @@ describe('HomePage', () => {
       LocalStorageVars.cookiesAccepted,
       `"${CookieStatus.accepted}"` // localStorage saves the data differently from our LocalStorageService
     );
-    cy.visit('/home');
+    cy.visit('/');
   });
 
   it('should contain a navbar and footer', () => {

--- a/apps/webstore-e2e/src/integration/pages/page-not-found.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/page-not-found.spec.ts
@@ -15,14 +15,14 @@ describe('PageNotFoundPage', () => {
 
   it('should redirect to home when the "home" button is clicked', () => {
     cy.get('[data-cy=page-not-found-home-btn]').click();
-    cy.url().should('contain', '/home');
+    cy.url().should('contain', '/');
   });
 
   it('should redirect to back to previous page (home) when the "back" button is clicked', () => {
-    cy.visit('/home');
+    cy.visit('/');
     cy.visit('/pageNotFound');
     cy.get('[data-cy=page-not-found-back-btn]').click();
-    cy.url().should('contain', '/home');
+    cy.url().should('contain', '/');
   });
 
   it('should be opened when invalid page is opened', () => {

--- a/apps/webstore-e2e/src/integration/services/localization/localization.spec.ts
+++ b/apps/webstore-e2e/src/integration/services/localization/localization.spec.ts
@@ -1,7 +1,6 @@
 describe('Localization', () => {
   beforeEach(() => {
     cy.visit('/');
-    cy.get('[data-cy=cookie-prompt-modal-accept-cookies-btn]').click();
   });
 
   it('change localized to danish', () => {
@@ -10,7 +9,7 @@ describe('Localization', () => {
     cy.get('[data-cy=navbar-localization-dk]').click();
 
     // check url to contain language
-    cy.url().should('include', '/da');
+    cy.url().should('not.include', '/da');
   });
 
   it('change localized to english', () => {

--- a/apps/webstore/src/app/app-routing.module.ts
+++ b/apps/webstore/src/app/app-routing.module.ts
@@ -21,7 +21,7 @@ import { ProductsComponent } from './pages/products/products.component';
 import { AuthGuard } from './shared/guards/auth/auth.guard';
 
 const routes: Routes = [
-  { path: 'home', component: HomeComponent }, // CookieGuard ensures that the user has accepted cookies
+  { path: '', pathMatch: 'full', component: HomeComponent }, // CookieGuard ensures that the user has accepted cookies
   { path: 'login', component: LoginComponent },
   {
     path: 'resetPassword/:token',
@@ -77,7 +77,6 @@ const routes: Routes = [
     path: 'checkout',
     component: CheckoutComponent,
   },
-  { path: '', pathMatch: 'full', redirectTo: 'home' }, // Redirect to home page
   { path: '**', component: PageNotFoundComponent }, // PageNotFound for all other page requests
 ];
 

--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -25,13 +25,22 @@ export class AppComponent {
     private errorlogsService: ErrorlogsService
   ) {
     // Setup localization language
-    this.router.events.subscribe(() => {
+    this.router.events.subscribe(async () => {
       const locale = this.localStorageService.getItem<LocaleType>(LocalStorageVars.locale).getValue();
       // if the website is deployed the url has locale in it and has to be adjusted to match local storage
-      if (window.location.href.includes('/en-US/') && locale === LocaleType.da) {
-        window.location.href = window.location.href.replace('/en-US/', '/da/');
-      } else if (window.location.href.includes('/da/') && locale === LocaleType.en) {
-        window.location.href = window.location.href.replace('/da/', '/en-US/');
+      console.log(window.location.href);
+      if (window.location.href.includes('/en-US') && locale === LocaleType.da) {
+        // English locale while the user has selected Danish
+        console.warn('Redirecting you to your chosen locale: DA');
+        window.location.href = window.location.href.replace('/en-US', '');
+      } else if (!window.location.href.includes('/en-US') && locale === LocaleType.en) {
+        // Danish locale while the user has selected English
+        console.warn('Redirecting you to your chosen locale: en-US');
+        window.location.href = window.location.origin + '/en-US' + window.location.pathname + window.location.search;
+      } else if (window.location.href.includes('/da')) {
+        console.log('removing /da');
+        await new Promise((f) => setTimeout(f, 1000));
+        window.location.href = window.location.href.replace('/da', '');
       }
     });
 

--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -38,9 +38,13 @@ export class AppComponent {
         console.warn('Redirecting you to your chosen locale: en-US');
         window.location.href = window.location.origin + '/en-US' + window.location.pathname + window.location.search;
       } else if (window.location.href.includes('/da')) {
-        console.log('removing /da');
-        await new Promise((f) => setTimeout(f, 1000));
+        // Legacy URL
+        console.warn('Redirecting you to our updated locale');
         window.location.href = window.location.href.replace('/da', '');
+      } else if (window.location.href.includes('/dk')) {
+        // Legacy URL
+        console.warn('Redirecting you to our updated locale');
+        window.location.href = window.location.href.replace('/dk', '');
       }
     });
 

--- a/apps/webstore/src/app/pages/payment-cancelled/payment-cancelled.component.html
+++ b/apps/webstore/src/app/pages/payment-cancelled/payment-cancelled.component.html
@@ -1,7 +1,7 @@
 <main class="cancelled-container">
     <div class="cancelled-content add-transition">
         <div class="back-to-home-container">
-            <a routerLink="/home" class="back-to-home add-transition">
+            <a routerLink="/" class="back-to-home add-transition">
                 < <span i18n="@@back-to-home">Back to home page </span>
             </a>
         </div>

--- a/apps/webstore/src/app/pages/payment-success/payment-success.component.html
+++ b/apps/webstore/src/app/pages/payment-success/payment-success.component.html
@@ -2,7 +2,7 @@
     <section class="success-content add-transition">
         <img src="/assets/logos/tc-black-text-logo.svg" alt="Treecreate logo" class="success-logo add-transition" />
         <div class="back-to-home-container">
-            <a routerLink="/home" class="back-to-home add-transition">
+            <a routerLink="/" class="back-to-home add-transition">
                 < <span i18n="@@back-to-home">Back to home page </span>
             </a>
         </div>

--- a/apps/webstore/src/app/shared/components/footer/footer.component.html
+++ b/apps/webstore/src/app/shared/components/footer/footer.component.html
@@ -9,7 +9,7 @@
                     <div class="col">
                         <ul class="list-unstyled">
                             <li>
-                                <a (click)="scrollTop()" routerLink="/home">Home</a>
+                                <a (click)="scrollTop()" routerLink="/">Home</a>
                             </li>
                             <li>
                                 <a (click)="scrollTop()" routerLink="/products" i18n="@@product">Products</a>

--- a/apps/webstore/src/app/shared/components/navbar/navbar.component.html
+++ b/apps/webstore/src/app/shared/components/navbar/navbar.component.html
@@ -58,7 +58,7 @@
                     <a
                         ngbDropdownItem
                         (click)="changeLocale('da')"
-                        href="/{{ localeCode }}/"
+                        href="/"
                         data-cy="navbar-localization-dk"
                         i18n="@@dansk"
                         >Dansk</a

--- a/apps/webstore/src/app/shared/components/navbar/navbar.component.html
+++ b/apps/webstore/src/app/shared/components/navbar/navbar.component.html
@@ -1,5 +1,5 @@
 <nav data-cy="navbar" class="navbar fixed-top navbar-expand-lg add-transition">
-    <div class="purchase-info" *ngIf="router.url === '/home'">
+    <div class="purchase-info" *ngIf="router.url === '/'">
         <span class="info-text">
             <span i18n="@@delivery-4-7">7 days delivery</span>
             <img src="/assets/icons/check-white-icon.svg" class="check-icon" alt="Hurtig levering icon" />
@@ -93,7 +93,7 @@
         <div [ngbCollapse]="isMenuCollapsed" class="collapse navbar-collapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                    <a class="nav-link waves-light" routerLink="/home" (click)="autoCollapse()">Home</a>
+                    <a class="nav-link waves-light" routerLink="/" (click)="autoCollapse()">Home</a>
                 </li>
                 <li class="nav-item">
                     <a

--- a/apps/webstore/src/app/shared/services/authentication/auth.service.ts
+++ b/apps/webstore/src/app/shared/services/authentication/auth.service.ts
@@ -95,7 +95,7 @@ export class AuthService {
     this.localStorageService.removeItem(LocalStorageVars.authUser);
     this.localStorageService.removeItem(LocalStorageVars.designFamilyTree);
     this.localStorageService.removeItem(LocalStorageVars.transactionItems);
-    this.router.navigate(['/home']);
+    this.router.navigate(['/']);
   }
 
   /**

--- a/apps/webstore/src/i18n/messages.da.xlf
+++ b/apps/webstore/src/i18n/messages.da.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en-US" datatype="plaintext" original="ng2.template" target-language="da">
+  <file source-language="en-US" datatype="plaintext" original="ng2.template" target-language="">
     <body>
     <trans-unit id="home-main-text-title" datatype="html">
         <source>A completely unique gift, exactly as you want it </source>

--- a/workspace.json
+++ b/workspace.json
@@ -319,7 +319,7 @@
       "i18n": {
         "sourceLocale": "en-US",
         "locales": {
-          "da": "apps/webstore/src/i18n/messages.da.xlf"
+          "": "apps/webstore/src/i18n/messages.da.xlf"
         }
       },
       "targets": {


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-215](https://treecreate.atlassian.net/browse/TC-215)

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [x] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- When the user selects a danish locale, the URL is the base website URL instead of including `/da` in it (`treecreate.dk/da/products `becomes `treecreate.dk/products`)
- Rename `/home` to just `/`
- Add handling of Legacy URLs, automatically redirecting `/dk` and `/da` to the new URL
- Adjust links provided in the emails etc

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage

<!--- Insert images here -->
