### PR TITLE
fix/#270 Change error log url max length from 50 to 100

### DIFF
--- a/apps/api/src/main/java/dk/treecreate/api/errorlog/Errorlog.java
+++ b/apps/api/src/main/java/dk/treecreate/api/errorlog/Errorlog.java
@@ -58,7 +58,7 @@ public class Errorlog {
   private String browser;
 
   @NotBlank
-  @Size(max = 50)
+  @Size(max = 100)
   @ApiModelProperty(name = "Page url", example = "https://treecreate.dk/login", required = true)
   private String url;
 

--- a/apps/api/src/main/java/dk/treecreate/api/errorlog/dto/CreateErrorlogRequest.java
+++ b/apps/api/src/main/java/dk/treecreate/api/errorlog/dto/CreateErrorlogRequest.java
@@ -29,7 +29,7 @@ public class CreateErrorlogRequest {
   private String browser;
 
   @NotBlank
-  @Size(max = 50)
+  @Size(max = 100)
   @ApiModelProperty(name = "Page url", example = "https://treecreate.dk/login", required = true)
   private String url;
 


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-270](https://treecreate.atlassian.net/browse/TC-270)

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [ ] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [x] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- Change the error log URL max length from 50 to 100 characters
- Update development, staging, and production databases to use the new value

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage

<!--- Insert images here -->
