### PR TITLE
Feat/#119 create trustpilot feedback email

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,5 +4,6 @@ TREECREATE_QUICKPAY_API_KEY=api_key_here
 TREECREATE_QUICKPAY_PRIVATE_KEY=private_key_goes_here
 TREECREATE_MAIL_PASS=mailer_password
 TREECREATE_SENTRY_DSN="" # Should be left blank for dev runs
+TREECREATE_TRUSTPILOT_AFS_EMAIL="" # The email of the trustpilot automatic feedback service
 SHIPMONDO_URL=https://app.shipmondo.com/api/public/v3
 SHIPMONDO_TOKEN=Basic username:password # credentials encoded in Base 64

--- a/apps/api/src/main/java/dk/treecreate/api/config/CustomPropertiesConfig.java
+++ b/apps/api/src/main/java/dk/treecreate/api/config/CustomPropertiesConfig.java
@@ -25,6 +25,8 @@ public class CustomPropertiesConfig {
 
   private int jwtRefreshExpirationMs;
 
+  private String trustpilotAFSEmail;
+
   public String getQuickpayApiKey() {
     return quickpayApiKey;
   }
@@ -95,5 +97,13 @@ public class CustomPropertiesConfig {
 
   public void setJwtRefreshExpirationMs(int jwtRefreshExpirationMs) {
     this.jwtRefreshExpirationMs = jwtRefreshExpirationMs;
+  }
+
+  public void setTrustpilotAFSEmail(String trustpilotAFSEmail) {
+    this.trustpilotAFSEmail = trustpilotAFSEmail;
+  }
+
+  public String getTrustpilotAFSEmail() {
+    return this.trustpilotAFSEmail;
   }
 }

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -30,6 +30,8 @@ treecreate.app.environment=${TREECREATE_ENV:DEVELOPMENT}
 treecreate.app.shipmondo-url=${SHIPMONDO_URL}
 treecreate.app.shipmondo-token=${SHIPMONDO_TOKEN}
 
+treecreate.app.trustpilotAFSEmail=${TREECREATE_TRUSTPILOT_AFS_EMAIL}
+
 # Log all requests
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-119](https://treecreate.atlassian.net/browse/TC-119)

### Which service(s) does this issue affect:

- [x] 🛰️ API
- [ ] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [x] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- Refactored mail service to add support for including black carbon copy (BCC) for sent emails
- Added environment variable for Trustpilot Automatic Feedback Service (AFS) email
- Update staging and production environments with the extra AFS env variable

AFS supports integration via sending an email to them and via just listing them as a black carbon copy (BCC). I went with the latter.

Since a large chunk of the mailService logic has been updated, extensive testing and validation of the mails in our system is needed. I've tested
- Newsletter signup email
- Custom order email
- Order Confirmation email + trustpilot AFS

### How should this be manually tested?

1. Add the trustpilot AFS email to the `.env` file (check `.env.example` file for the name)
2. Run the API and the webstore apps
3. Create an order
4. Log into Treecreate's trustpilot
5. Navigate to trustpilot's Get Reviews > Invitation Status page 
6. The list should include the email associated with the order
Alternatively, put in your own email in the .env instead of the AFS one. It should receive a BCC of the order confirmation email

### Screenshots or example usage

#### Trustpilot's list of invites

*Erased my email since this repo is public and this is my private email*
![image](https://user-images.githubusercontent.com/22862227/194696892-19574cde-b370-4e0e-b59a-540f46f0942e.png)
