### PR TITLE
Feat/#276 log every page change

### DIFF
--- a/apps/webstore-e2e/src/integration/pages/auth/login.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/login.spec.ts
@@ -17,7 +17,7 @@ describe('Login Page', () => {
     });
 
     it('should properly authenticate user with correct credentials', () => {
-      cy.intercept('POST', `/auth/signin`, {
+      cy.intercept('POST', `/auth/signin*`, {
         body: authMockService.getMockUser(AuthUserEnum.authUser),
         statusCode: 200,
       }).as('signinRequest');
@@ -33,7 +33,7 @@ describe('Login Page', () => {
     });
 
     it('should refuse signin for user with incorrect credentials', () => {
-      cy.intercept('POST', `/auth/signin`, {
+      cy.intercept('POST', `/auth/signin*`, {
         body: 'Unauthorized',
         statusCode: 401,
       }).as('signinRequest');

--- a/apps/webstore-e2e/src/integration/pages/auth/signup.spec.ts
+++ b/apps/webstore-e2e/src/integration/pages/auth/signup.spec.ts
@@ -17,7 +17,7 @@ describe('Signup Page', () => {
     });
 
     it('should properly create a new user with correct credentials', () => {
-      cy.intercept('POST', `/auth/signup?lang=da`, {
+      cy.intercept('POST', `/auth/signup*`, {
         body: authMockService.getMockUser(AuthUserEnum.authUser),
         statusCode: 200,
       }).as('signupRequest');
@@ -36,7 +36,7 @@ describe('Signup Page', () => {
     });
 
     it('should refuse signup for user with incorrect credentials', () => {
-      cy.intercept('POST', `/auth/signup`, {
+      cy.intercept('POST', `/auth/signup*`, {
         body: authMockService.getMockUser(AuthUserEnum.authUser),
         statusCode: 200,
       }).as('signupRequest');

--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -28,8 +28,10 @@ export class AppComponent {
     private errorlogsService: ErrorlogsService
   ) {
     // Setup localization language
-    this.router.events.subscribe(async () => {
-      this.updateLocale();
+    this.router.events.subscribe(async (val) => {
+      if (val instanceof NavigationEnd) {
+        this.updateLocale();
+      }
     });
     this.localStorageService.getItem(LocalStorageVars.locale).subscribe(async () => {
       this.updateLocale();

--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { LocalStorageService } from '@local-storage';
 import { CookieStatus, LocaleType, LocalStorageVars } from '@models';
 import { environment } from '../environments/environment';
 import { ErrorlogsService } from './shared/services/errorlog/errorlog.service';
+import { EventsService } from './shared/services/events/events.service';
 
 // Google analytics-specific syntax
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -23,6 +24,7 @@ export class AppComponent {
   constructor(
     public router: Router,
     private localStorageService: LocalStorageService,
+    private eventsService: EventsService,
     private errorlogsService: ErrorlogsService
   ) {
     // Setup localization language
@@ -41,6 +43,13 @@ export class AppComponent {
         this.initMetaPixel();
       } else {
         console.log('Not logging Google analytics nor Meta Pixel since cookies were not accepted');
+      }
+    });
+
+    // Log every page change
+    this.router.events.subscribe(async (val) => {
+      if (val instanceof NavigationEnd) {
+        this.eventsService.create('webstore.page-viewed');
       }
     });
 


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-276](https://treecreate.atlassian.net/browse/TC-276)

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [ ] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [x] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- All URL changes result in logging a `webstore.page-viewed` event. The URL field can be used to find out what page has been opened
- Optimized logic for updating locale based on URL changes. Before each page load was 6-10 calls

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage

<!--- Insert images here -->
