### PR TITLE
Feat/#280 Handle not logged in users trying to checkout using email of existing user

### DIFF
--- a/apps/webstore/src/app/pages/auth/checkout/checkout.component.ts
+++ b/apps/webstore/src/app/pages/auth/checkout/checkout.component.ts
@@ -482,15 +482,24 @@ export class CheckoutComponent implements OnInit {
           password: passwordGen,
         })
         .toPromise()
-        .catch((error) => {
+        .catch((error: HttpErrorResponse) => {
           console.warn(error);
           this.errorlogsService.create('webstore.checkout.register-on-order-failed', ErrorlogPriorityEnum.high, error);
-          this.toastService.showAlert(
-            'Failed to create order, please try again',
-            'Der skete en fejl ved ordren, prøv venligst igen',
-            'danger',
-            5000
-          );
+          if (error.error.message === 'Error: Email is already in use!') {
+            this.toastService.showAlert(
+              'The provided email is already in use. Please log in before creating a new order. Your existing basket will remain unchanged.',
+              'Din email er allerede oprettet som bruger. Log ind og prøv igen. Produkterne i din kurv bliver tilkoblet din konto når du logger ind så de ikke forsvinder.',
+              'danger',
+              20000
+            );
+          } else {
+            this.toastService.showAlert(
+              'Failed to create order, please try again',
+              'Der skete en fejl ved ordren, prøv venligst igen',
+              'danger',
+              10000
+            );
+          }
           this.isLoading = false;
         });
 


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-280](https://treecreate.atlassian.net/browse/TC-280)

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- Original solution proved to be more complex (rework of how designs and transaction items are uploaded and persisted), so instead we will simply display a more specific message when the user tries to check out using an email that is already registered.

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage
![image](https://user-images.githubusercontent.com/22862227/198378881-d7cdfb07-da59-428e-a928-1e35473e8396.png)
