### PR TITLE
Feat/#278 log where user was redirected from

### DIFF
--- a/apps/webstore/src/app/app.component.ts
+++ b/apps/webstore/src/app/app.component.ts
@@ -31,6 +31,20 @@ export class AppComponent {
     this.router.events.subscribe(async (val) => {
       if (val instanceof NavigationEnd) {
         this.updateLocale();
+        // log as event if the redirect happened from a website other than Treecreate
+        const referrer = document.referrer;
+        if (
+          !referrer.includes('https://treecreate') &&
+          !referrer.includes('https://testing.treecreate') &&
+          !referrer.includes('http://localhost')
+        ) {
+          // clean up the string and shorten it if needed
+          let host = referrer.replace('https://', '').replace('http://', '');
+          if (host.length > 50) {
+            host = host.slice(0, 50);
+          }
+          this.eventsService.create(`webstore.visited-from.${host}`);
+        }
       }
     });
     this.localStorageService.getItem(LocalStorageVars.locale).subscribe(async () => {


### PR DESCRIPTION
### This pull request closes:

✔️ Closes Jira Issue: [TC-278](https://treecreate.atlassian.net/browse/TC-278)

### Which service(s) does this issue affect:

- [ ] 🛰️ API
- [x] 🛒 webstore
- [ ] 🎓 admin-page

### Types of changes

- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [x] 🧱 New feature (a non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🤖 CI/CD (a change to the CI/CD pipeline)
- [ ] ⚗️ Refactoring (an update to some already existing code)
- [ ] 💄 Style (Markup, formatting, CSS)

### Documentation Updates

- [x] 📂 No need for updates
- [ ] 📁 Requires an update ( _not done within this issue_ )
- [ ] 🗃️ Has been updated ( _done within this issue_ )

### Testing checklist

- [x] 💪 Manual tests
- [ ] 🔧 Automatic tests

#### Browser compatibility - _**[**Frontend only**]**_

- [ ] Tested on Safari
- [x] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

- New event: `webstore.visited-from.<referrer>`
- Utilizes `document.referrer` logic to determine where it got redirected from
- Facebook does get caught, but Instagram may not (I don't know if they do set the referrer)
- It is not an absolute solution, but we can also do tricks we how we link treecreate in the first place, and then easily find the referrals via the page-viewed event

### How should this be manually tested?

<!--- Write the steps here -->

### Screenshots or example usage

<!--- Insert images here -->
